### PR TITLE
Add support for sending process information

### DIFF
--- a/jaeger-client.gemspec
+++ b/jaeger-client.gemspec
@@ -2,9 +2,11 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'jaeger/client/version'
+
 Gem::Specification.new do |spec|
   spec.name          = 'jaeger-client'
-  spec.version       = '0.4.1'
+  spec.version       = Jaeger::Client::VERSION
   spec.authors       = ['SaleMove TechMovers']
   spec.email         = ['techmovers@salemove.com']
 

--- a/lib/jaeger/client.rb
+++ b/lib/jaeger/client.rb
@@ -9,6 +9,7 @@ require_relative 'client/carrier'
 require_relative 'client/trace_id'
 require_relative 'client/udp_sender'
 require_relative 'client/collector'
+require_relative 'client/version'
 
 module Jaeger
   module Client

--- a/lib/jaeger/client/version.rb
+++ b/lib/jaeger/client/version.rb
@@ -1,0 +1,6 @@
+
+module Jaeger
+  module Client
+    VERSION = '0.4.1'.freeze
+  end
+end


### PR DESCRIPTION
Sends the version and language of the library used, the self-detected
hostname and IPv4 address if available inspired by how other
jaeger-client libraries do it: https://github.com/jaegertracing/jaeger-client-java/blob/bc49ab7303bbb0d96e5fd5c1d960110d7294f5b8/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java#L98-L113