### PR TITLE
Do not reuse socket#connect

### DIFF
--- a/lib/jaeger/client/udp_sender/transport.rb
+++ b/lib/jaeger/client/udp_sender/transport.rb
@@ -6,7 +6,8 @@ module Jaeger
 
         def initialize(host, port)
           @socket = UDPSocket.new
-          @socket.connect(host, port)
+          @host = host
+          @port = port
           @buffer = ::Thrift::MemoryBufferTransport.new
         end
 
@@ -26,7 +27,7 @@ module Jaeger
         private
 
         def send_bytes(bytes)
-          @socket.send(bytes, FLAGS)
+          @socket.send(bytes, FLAGS, @host, @port)
           @socket.flush
         rescue Errno::ECONNREFUSED
           warn 'Unable to connect to Jaeger Agent'


### PR DESCRIPTION
Hi!

There is a small problem with UDP transport initialization. If _host_ won’t be available on Transport::initialize then @socket.connect will raise an exception.

PR fixes that bug.