### PR TITLE
Rescue thrift errors in UdpSender and add logger

### DIFF
--- a/lib/jaeger/client.rb
+++ b/lib/jaeger/client.rb
@@ -4,6 +4,7 @@ $LOAD_PATH.push(File.dirname(__FILE__) + '/../../thrift/gen-rb')
 
 require 'opentracing'
 require 'jaeger/thrift/agent'
+require 'logger'
 
 require_relative 'client/tracer'
 require_relative 'client/span'
@@ -25,14 +26,16 @@ module Jaeger
                    port: 6831,
                    service_name:,
                    flush_interval: DEFAULT_FLUSH_INTERVAL,
-                   sampler: Samplers::Const.new(true))
+                   sampler: Samplers::Const.new(true),
+                   logger: Logger.new(STDOUT))
       collector = Collector.new
       sender = UdpSender.new(
         service_name: service_name,
         host: host,
         port: port,
         collector: collector,
-        flush_interval: flush_interval
+        flush_interval: flush_interval,
+        logger: logger
       )
       sender.start
       Tracer.new(collector, sender, sampler)


### PR DESCRIPTION
Hi! I've added this pull request as it may be worth to merging.

Why:
We have multiple problems with UdpSender thread dying all the time (and even kill an app which has Thread.abort_on_exception enabled). This additions allows to log errors and skip failed batches.