### PR TITLE
Correctly transform big unsigned ints to thrift signed ints

### DIFF
--- a/lib/jaeger/client/collector.rb
+++ b/lib/jaeger/client/collector.rb
@@ -15,10 +15,10 @@ module Jaeger
         return if !context.sampled? && !context.debug?
 
         @buffer << Jaeger::Thrift::Span.new(
-          'traceIdLow' => context.trace_id,
+          'traceIdLow' => context.thrift_trace_id,
           'traceIdHigh' => 0,
-          'spanId' => context.span_id,
-          'parentSpanId' => context.parent_id,
+          'spanId' => context.thrift_span_id,
+          'parentSpanId' => context.thrift_parent_id,
           'operationName' => span.operation_name,
           'references' => build_references(span.references || []),
           'flags' => context.flags,
@@ -39,9 +39,9 @@ module Jaeger
         references.map do |ref|
           Jaeger::Thrift::SpanRef.new(
             'refType' => span_ref_type(ref.type),
-            'traceIdLow' => ref.context.trace_id,
+            'traceIdLow' => ref.context.thrift_trace_id,
             'traceIdHigh' => 0,
-            'spanId' => ref.context.span_id
+            'spanId' => ref.context.thrift_span_id
           )
         end
       end

--- a/lib/jaeger/client/span_context.rb
+++ b/lib/jaeger/client/span_context.rb
@@ -4,6 +4,10 @@ module Jaeger
   module Client
     # SpanContext holds the data for a span that gets inherited to child spans
     class SpanContext
+      MAX_SIGNED_ID = (1 << 63) - 1
+      MAX_UNSIGNED_ID = (1 << 64)
+      ID_ATTRIBUTES = %i[span_id parent_id trace_id]
+
       module Flags
         NONE = 0x00
         SAMPLED = 0x01
@@ -25,7 +29,13 @@ module Jaeger
         new(span_id: span_id, parent_id: parent_id, trace_id: trace_id, flags: flags)
       end
 
-      attr_reader :span_id, :parent_id, :trace_id, :baggage, :flags
+      attr_reader :baggage, :flags, *ID_ATTRIBUTES
+
+      ID_ATTRIBUTES.each do |attribute|
+        define_method "thrift_#{attribute}" do
+          id_to_thrift_int(self.public_send(attribute))
+        end
+      end
 
       def initialize(span_id:, parent_id: 0, trace_id:, flags:, baggage: {})
         @span_id = span_id
@@ -52,6 +62,16 @@ module Jaeger
           "@parent_id=#{parent_id.to_s(16)} " \
           "@trace_id=#{trace_id.to_s(16)} " \
           "@flags=#{flags}>"
+      end
+
+      private
+
+      def id_to_thrift_int(id)
+        return unless id
+
+        puts id
+        id -= MAX_UNSIGNED_ID if id > MAX_SIGNED_ID
+        id
       end
     end
   end

--- a/lib/jaeger/client/span_context.rb
+++ b/lib/jaeger/client/span_context.rb
@@ -6,7 +6,7 @@ module Jaeger
     class SpanContext
       MAX_SIGNED_ID = (1 << 63) - 1
       MAX_UNSIGNED_ID = (1 << 64)
-      ID_ATTRIBUTES = %i[span_id parent_id trace_id]
+      ID_ATTRIBUTES = %i[span_id parent_id trace_id].freeze
 
       module Flags
         NONE = 0x00
@@ -33,7 +33,7 @@ module Jaeger
 
       ID_ATTRIBUTES.each do |attribute|
         define_method "thrift_#{attribute}" do
-          id_to_thrift_int(self.public_send(attribute))
+          id_to_thrift_int(public_send(attribute))
         end
       end
 
@@ -69,7 +69,6 @@ module Jaeger
       def id_to_thrift_int(id)
         return unless id
 
-        puts id
         id -= MAX_UNSIGNED_ID if id > MAX_SIGNED_ID
         id
       end

--- a/lib/jaeger/client/trace_id.rb
+++ b/lib/jaeger/client/trace_id.rb
@@ -3,7 +3,7 @@
 module Jaeger
   module Client
     module TraceId
-      TRACE_ID_UPPER_BOUND = 2**63 - 1
+      TRACE_ID_UPPER_BOUND = 2**64 - 1
 
       def self.generate
         rand(TRACE_ID_UPPER_BOUND)

--- a/lib/jaeger/client/tracer.rb
+++ b/lib/jaeger/client/tracer.rb
@@ -174,17 +174,11 @@ module Jaeger
         return nil if trace_id.zero? || span_id.zero?
 
         SpanContext.new(
-          trace_id: to_signed_int(trace_id, 64),
-          parent_id: to_signed_int(parent_id, 64),
-          span_id: to_signed_int(span_id, 64),
+          trace_id: trace_id,
+          parent_id: parent_id,
+          span_id: span_id,
           flags: flags
         )
-      end
-
-      def to_signed_int(num, bits)
-        # Using two's complement
-        mask = 2**(bits - 1)
-        (num & ~mask) - (num & mask)
       end
 
       def prepare_span_context(child_of:, references:, ignore_active_scope:)

--- a/spec/jaeger/client/collector_spec.rb
+++ b/spec/jaeger/client/collector_spec.rb
@@ -46,11 +46,11 @@ RSpec.describe Jaeger::Client::Collector do
       end
     end
 
-    context 'parsing ids for thrift specific sizes' do
+    context 'when parsing ids for thrift specific size' do
       # on 64-bits you can actually put 18446744073709551616 numbers
       # thrift support sending -9223372036854775808 to 9223372036854775807
-      let(:hexa_negative_int64) { 18446744073709551615 } # -1
-      let(:hexa_positive_int64) { 9223372036854775807 } # max positive
+      let(:hexa_negative_int64) { 18_446_744_073_709_551_615 } # -1
+      let(:hexa_positive_int64) { 9_223_372_036_854_775_807 } # max positive
 
       before do
         allow(Jaeger::Thrift::Span).to receive(:new).and_call_original

--- a/spec/jaeger/client/collector_spec.rb
+++ b/spec/jaeger/client/collector_spec.rb
@@ -5,10 +5,15 @@ RSpec.describe Jaeger::Client::Collector do
   let(:operation_name) { 'op-name' }
 
   describe '#send_span' do
+    let(:trace_id) { Jaeger::Client::TraceId.generate }
+    let(:span_id) { Jaeger::Client::TraceId.generate }
+    let(:parent_id) { Jaeger::Client::TraceId.generate }
+    let(:flags) { Jaeger::Client::SpanContext::Flags::SAMPLED }
     let(:context) do
       Jaeger::Client::SpanContext.new(
-        trace_id: Jaeger::Client::TraceId.generate,
-        span_id: Jaeger::Client::TraceId.generate,
+        trace_id: trace_id,
+        span_id: span_id,
+        parent_id: parent_id,
         flags: flags
       )
     end
@@ -38,6 +43,67 @@ RSpec.describe Jaeger::Client::Collector do
       it 'does not buffer the span' do
         collector.send_span(span, Time.now)
         expect(collector.retrieve).to be_empty
+      end
+    end
+
+    context 'parsing ids for thrift specific sizes' do
+      # on 64-bits you can actually put 18446744073709551616 numbers
+      # thrift support sending -9223372036854775808 to 9223372036854775807
+      let(:hexa_negative_int64) { 18446744073709551615 } # -1
+      let(:hexa_positive_int64) { 9223372036854775807 } # max positive
+
+      before do
+        allow(Jaeger::Thrift::Span).to receive(:new).and_call_original
+
+        collector.send_span(span, Time.now)
+      end
+
+      context 'when trace-id is a negative int64' do
+        let(:trace_id) { hexa_negative_int64 }
+
+        it 'interprets it correctly' do
+          expect(Jaeger::Thrift::Span).to have_received(:new).with(hash_including('traceIdLow' => -1))
+        end
+      end
+
+      context 'when trace-id is a positive int64' do
+        let(:trace_id) { hexa_positive_int64 }
+
+        it 'interprets it correctly' do
+          expect(Jaeger::Thrift::Span).to have_received(:new).with(hash_including('traceIdLow' => 2**63 - 1))
+        end
+      end
+
+      context 'when parent-id is a negative int64' do
+        let(:parent_id) { hexa_negative_int64 }
+
+        it 'interprets it correctly' do
+          expect(Jaeger::Thrift::Span).to have_received(:new).with(hash_including('parentSpanId' => -1))
+        end
+      end
+
+      context 'when parent-id is a positive int64' do
+        let(:parent_id) { hexa_positive_int64 }
+
+        it 'interprets it correctly' do
+          expect(Jaeger::Thrift::Span).to have_received(:new).with(hash_including('parentSpanId' => 2**63 - 1))
+        end
+      end
+
+      context 'when span-id is a negative int64' do
+        let(:span_id) { hexa_negative_int64 }
+
+        it 'interprets it correctly' do
+          expect(Jaeger::Thrift::Span).to have_received(:new).with(hash_including('spanId' => -1))
+        end
+      end
+
+      context 'when span-id is a positive int64' do
+        let(:span_id) { hexa_positive_int64 }
+
+        it 'interprets it correctly' do
+          expect(Jaeger::Thrift::Span).to have_received(:new).with(hash_including('spanId' => 2**63 - 1))
+        end
       end
     end
   end

--- a/spec/jaeger/client/samplers/probabilistic_spec.rb
+++ b/spec/jaeger/client/samplers/probabilistic_spec.rb
@@ -16,12 +16,12 @@ RSpec.describe Jaeger::Client::Samplers::Probabilistic do
     let(:rate) { 0.5 }
 
     it 'returns false for traces over the boundary' do
-      trace_id = (0.51 * (2**63 - 1)).to_i
+      trace_id = (0.51 * (2**64 - 1)).to_i
       expect(sampler.sample?(trace_id)).to eq(false)
     end
 
     it 'returns true for traces under the boundary' do
-      trace_id = (0.49 * (2**63 - 1)).to_i
+      trace_id = (0.49 * (2**64 - 1)).to_i
       expect(sampler.sample?(trace_id)).to eq(true)
     end
   end

--- a/spec/jaeger/client/tracer_spec.rb
+++ b/spec/jaeger/client/tracer_spec.rb
@@ -6,7 +6,7 @@ describe Jaeger::Client::Tracer do
   let(:sender) { spy }
   let(:sampler) { Jaeger::Client::Samplers::Const.new(true) }
 
-  context 'after #extract and #inject' do
+  context 'when using #extract and #inject' do
     UBER_TRACE_IDS = %w[
       c94f3977ee9a073:69548f7c197ab707:10bc37238fcf6732:1
       7ee9a073:69548f7c197ab707:10bc37238fcf6732:1
@@ -17,7 +17,7 @@ describe Jaeger::Client::Tracer do
       5288f24bd7783293:69548f7c197ab707:10bc37238fcf6732:1
       6e7c7815b3ba63b9dd8c8687003a4ff1:69548f7c197ab707:10bc37238fcf6732:1
       7815b3ba63b9dd8c8687003a4ff1:69548f7c197ab707:10bc37238fcf6732:1
-    ]
+    ].freeze
 
     UBER_TRACE_IDS.each do |uti|
       it "uber-trace-id: #{uti} is the same" do

--- a/spec/jaeger/client/tracer_spec.rb
+++ b/spec/jaeger/client/tracer_spec.rb
@@ -6,6 +6,30 @@ describe Jaeger::Client::Tracer do
   let(:sender) { spy }
   let(:sampler) { Jaeger::Client::Samplers::Const.new(true) }
 
+  context 'after #extract and #inject' do
+    UBER_TRACE_IDS = %w[
+      c94f3977ee9a073:69548f7c197ab707:10bc37238fcf6732:1
+      7ee9a073:69548f7c197ab707:10bc37238fcf6732:1
+      ffffffffffffffff:69548f7c197ab707:10bc37238fcf6732:1
+      -1:69548f7c197ab707:10bc37238fcf6732:1
+      -10000000000000001:69548f7c197ab707:10bc37238fcf6732:1
+      7fffffffffffffff:69548f7c197ab707:10bc37238fcf6732:1
+      5288f24bd7783293:69548f7c197ab707:10bc37238fcf6732:1
+      6e7c7815b3ba63b9dd8c8687003a4ff1:69548f7c197ab707:10bc37238fcf6732:1
+      7815b3ba63b9dd8c8687003a4ff1:69548f7c197ab707:10bc37238fcf6732:1
+    ]
+
+    UBER_TRACE_IDS.each do |uti|
+      it "uber-trace-id: #{uti} is the same" do
+        carrier = { 'uber-trace-id' => uti.dup }
+        span_context = tracer.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
+        tracer.inject(span_context, OpenTracing::FORMAT_TEXT_MAP, carrier)
+
+        expect(carrier['uber-trace-id']).to eq(uti)
+      end
+    end
+  end
+
   describe '#start_span' do
     let(:operation_name) { 'operator-name' }
 
@@ -210,7 +234,7 @@ describe Jaeger::Client::Tracer do
         let(:trace_id) { hexa_negative_int64 }
 
         it 'interprets it correctly' do
-          expect(span_context.trace_id).to eq(-1)
+          expect(span_context.trace_id).to eq(hexa_negative_int64.to_i(16))
         end
       end
 
@@ -226,7 +250,7 @@ describe Jaeger::Client::Tracer do
         let(:parent_id) { hexa_negative_int64 }
 
         it 'interprets it correctly' do
-          expect(span_context.parent_id).to eq(-1)
+          expect(span_context.parent_id).to eq(hexa_negative_int64.to_i(16))
         end
       end
 
@@ -242,7 +266,7 @@ describe Jaeger::Client::Tracer do
         let(:span_id) { hexa_negative_int64 }
 
         it 'interprets it correctly' do
-          expect(span_context.span_id).to eq(-1)
+          expect(span_context.span_id).to eq(hexa_negative_int64.to_i(16))
         end
       end
 
@@ -291,7 +315,7 @@ describe Jaeger::Client::Tracer do
         let(:trace_id) { hexa_negative_int64 }
 
         it 'interprets it correctly' do
-          expect(span_context.trace_id).to eq(-1)
+          expect(span_context.trace_id).to eq(hexa_negative_int64.to_i(16))
         end
       end
 
@@ -307,7 +331,7 @@ describe Jaeger::Client::Tracer do
         let(:parent_id) { hexa_negative_int64 }
 
         it 'interprets it correctly' do
-          expect(span_context.parent_id).to eq(-1)
+          expect(span_context.parent_id).to eq(hexa_negative_int64.to_i(16))
         end
       end
 
@@ -323,7 +347,7 @@ describe Jaeger::Client::Tracer do
         let(:span_id) { hexa_negative_int64 }
 
         it 'interprets it correctly' do
-          expect(span_context.span_id).to eq(-1)
+          expect(span_context.span_id).to eq(hexa_negative_int64.to_i(16))
         end
       end
 


### PR DESCRIPTION
Hi! I've noticed that something is off with trace_id parsing. Using method Tracer#extract and Tracer#inject should return same value (at least in integer) however it was changing it.

I've looked at official python client (especially this line: https://github.com/jaegertracing/jaeger-client-python/blob/master/jaeger_client/thrift.py#L29) and it looks like a better way to go with changing 64bit unsigned ints to 64bit signed ones.

Additionally I've enlarged `TRACE_ID_UPPER_BOUND` to `2**64 - 1`

If you don't like `define_method` let me know, I'll change it to `def`s :) 