### PR TITLE
Add a http sender

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ OpenTracing.start_active_span('span name') do
 end
 ```
 
+The tracer can also take an externally configured sender. For example, the `HttpSender` can be configured with a different endpoint and headers for authentication.
+```ruby
+require 'jaeger/client'
+require 'jaeger/client/http_sender'
+
+headers = { "auth_token" => token }
+encoder = Jaeger::Client::Encoders::ThriftEncoder.new(service_name: "service_name")
+sender = Jaeger::Client::HttpSender.new(url: "http://localhost:14268/api/traces", headers: headers, encoder: encoder)
+
+OpenTracing.global_tracer = Jaeger::Client.build(service_name: "service_name", sender: sender)
+```
+
 See [opentracing-ruby](https://github.com/opentracing/opentracing-ruby) for more examples.
 
 ### Samplers

--- a/lib/jaeger/client.rb
+++ b/lib/jaeger/client.rb
@@ -28,9 +28,14 @@ module Jaeger
                    service_name:,
                    flush_interval: DEFAULT_FLUSH_INTERVAL,
                    sampler: Samplers::Const.new(true),
-                   logger: Logger.new(STDOUT))
+                   logger: Logger.new(STDOUT),
+                   sender: nil)
       encoder = Encoders::ThriftEncoder.new(service_name: service_name)
-      sender = UdpSender.new(host: host, port: port, encoder: encoder, logger: logger)
+
+      if sender == nil
+        sender = UdpSender.new(host: host, port: port, encoder: encoder, logger: logger)
+      end
+
       reporter = AsyncReporter.create(sender: sender, flush_interval: flush_interval)
       Tracer.new(reporter, sampler)
     end

--- a/lib/jaeger/client.rb
+++ b/lib/jaeger/client.rb
@@ -32,7 +32,7 @@ module Jaeger
                    sender: nil)
       encoder = Encoders::ThriftEncoder.new(service_name: service_name)
 
-      if sender == nil
+      if sender.nil?
         sender = UdpSender.new(host: host, port: port, encoder: encoder, logger: logger)
       end
 

--- a/lib/jaeger/client/http_sender.rb
+++ b/lib/jaeger/client/http_sender.rb
@@ -5,7 +5,7 @@ require 'logger'
 module Jaeger
   module Client
     class HttpSender
-      def initialize(url:, headers:, encoder:, logger: Logger.new(STDOUT))
+      def initialize(url:, headers: {}, encoder:, logger: Logger.new(STDOUT))
         @encoder = encoder
         @logger = logger
 

--- a/lib/jaeger/client/http_sender.rb
+++ b/lib/jaeger/client/http_sender.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require_relative './http_sender/transport'
+require 'logger'
 
 module Jaeger
   module Client
-    module HttpSender
-      def initialize(host:, port:, endpoint:, headers:, encoder:, logger:)
+    class HttpSender
+      def initialize(host:, port:, endpoint:, headers:, encoder:, logger: Logger.new(STDOUT))
         @encoder = encoder
         @logger = logger
 

--- a/lib/jaeger/client/http_sender.rb
+++ b/lib/jaeger/client/http_sender.rb
@@ -13,13 +13,14 @@ module Jaeger
         @uri.query = 'format=jaeger.thrift'
 
         @transport = ::Thrift::HTTPClientTransport.new(@uri.to_s)
-
         @transport.add_headers(headers)
+
+        @serializer = ::Thrift::Serializer.new
       end
 
       def send_spans(spans)
         batch = @encoder.encode(spans)
-        @transport.write(::Thrift::Serializer.new.serialize(batch))
+        @transport.write(@serializer.serialize(batch))
         @transport.flush
       rescue StandardError => error
         @logger.error("Failure while sending a batch of spans: #{error}")

--- a/lib/jaeger/client/http_sender.rb
+++ b/lib/jaeger/client/http_sender.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative './http_sender/transport'
+
+module Jaeger
+  module Client
+    module HttpSender
+      def initialize(host:, port:, endpoint:, headers:, encoder:, logger:)
+        @encoder = encoder
+        @logger = logger
+
+        @uri = URI(host)
+        @uri.port = port
+        @uri.path = endpoint
+        @uri.query = "format=jaeger.thrift"
+
+        @transport = ::Thrift::HTTPClientTransport.new(@uri.to_s)
+
+        @transport.add_headers(headers)
+      end
+
+      def send_spans(spans)
+        batch = @encoder.encode(spans)
+        @transport.write(::Thrift::Serializer.new.serialize(batch))
+        @transport.flush()
+      rescue StandardError => error
+        @logger.error("Failure while sending a batch of spans: #{error}")
+      end
+    end
+  end
+end

--- a/lib/jaeger/client/http_sender.rb
+++ b/lib/jaeger/client/http_sender.rb
@@ -5,13 +5,11 @@ require 'logger'
 module Jaeger
   module Client
     class HttpSender
-      def initialize(host:, port:, endpoint:, headers:, encoder:, logger: Logger.new(STDOUT))
+      def initialize(url:, headers:, encoder:, logger: Logger.new(STDOUT))
         @encoder = encoder
         @logger = logger
 
-        @uri = URI(host)
-        @uri.port = port
-        @uri.path = endpoint
+        @uri = URI(url)
         @uri.query = 'format=jaeger.thrift'
 
         @transport = ::Thrift::HTTPClientTransport.new(@uri.to_s)

--- a/lib/jaeger/client/http_sender.rb
+++ b/lib/jaeger/client/http_sender.rb
@@ -12,7 +12,7 @@ module Jaeger
         @uri = URI(host)
         @uri.port = port
         @uri.path = endpoint
-        @uri.query = "format=jaeger.thrift"
+        @uri.query = 'format=jaeger.thrift'
 
         @transport = ::Thrift::HTTPClientTransport.new(@uri.to_s)
 
@@ -22,7 +22,7 @@ module Jaeger
       def send_spans(spans)
         batch = @encoder.encode(spans)
         @transport.write(::Thrift::Serializer.new.serialize(batch))
-        @transport.flush()
+        @transport.flush
       rescue StandardError => error
         @logger.error("Failure while sending a batch of spans: #{error}")
       end


### PR DESCRIPTION
This adds a wrapper around the thrift HTTP transport and directly sends batches to http endpoints.

Also, made a small change to the Client to allow passing in a sender, or to create the UDPSender by default to avoid breaking old behavior.