### PR TITLE
B3 propagation

### DIFF
--- a/lib/jaeger/client.rb
+++ b/lib/jaeger/client.rb
@@ -32,7 +32,7 @@ module Jaeger
                    sampler: Samplers::Const.new(true),
                    logger: Logger.new(STDOUT),
                    sender: nil,
-                   propagate_b3: false)
+                   propagation_codec: Jaeger::Client::PropagationCodec::JaegerCodec)
       encoder = Encoders::ThriftEncoder.new(service_name: service_name)
 
       if sender.nil?
@@ -41,13 +41,7 @@ module Jaeger
 
       reporter = AsyncReporter.create(sender: sender, flush_interval: flush_interval)
 
-      codec = if propagate_b3
-                PropagationCodec::B3Codec.new
-              else
-                PropagationCodec::JaegerCodec.new
-              end
-
-      Tracer.new(reporter, sampler, codec)
+      Tracer.new(reporter, sampler, propagation_codec)
     end
   end
 end

--- a/lib/jaeger/client.rb
+++ b/lib/jaeger/client.rb
@@ -41,11 +41,11 @@ module Jaeger
 
       reporter = AsyncReporter.create(sender: sender, flush_interval: flush_interval)
 
-      if propagate_b3
-        codec = PropagationCodec::B3Codec.new
-      else
-        codec = PropagationCodec::JaegerCodec.new
-      end
+      codec = if propagate_b3
+                PropagationCodec::B3Codec.new
+              else
+                PropagationCodec::JaegerCodec.new
+              end
 
       Tracer.new(reporter, sampler, codec)
     end

--- a/lib/jaeger/client/propagation_codec/b3_codec.rb
+++ b/lib/jaeger/client/propagation_codec/b3_codec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Jaeger
+  module Client
+    module PropagationCodec
+      class B3Codec
+
+        # Inject a SpanContext into the given carrier
+        #
+        # @param span_context [SpanContext]
+        # @param carrier [carrier] A carrier object of type TEXT_MAP or RACK
+        def inject(span_context, carrier)
+          carrier['x-b3-traceid'] = to_hex(span_context.trace_id)
+          carrier['x-b3-spanid'] = to_hex(span_context.span_id)
+          carrier['x-b3-parentspanid'] = to_hex(span_context.parent_id)
+
+          # flags (for debug) and sampled headers are mutually exclusive
+          if span_context.flags == Jaeger::Client::SpanContext::Flags::DEBUG
+            carrier['x-b3-flags'] = "1"
+          else
+            carrier['x-b3-sampled'] = span_context.flags.to_s(16)
+          end
+        end
+
+        # Extract a SpanContext from a given carrier in the Text Map format
+        #
+        # @param carrier [Carrier] A carrier of type Text Map
+        # @return [SpanContext] the extracted SpanContext or nil if none was extracted
+        def extract_text_map(carrier)
+          trace_id = TraceId.base16_hex_id_to_uint64(carrier['x-b3-traceid'])
+          span_id = TraceId.base16_hex_id_to_uint64(carrier['x-b3-spanid'])
+          parent_id = TraceId.base16_hex_id_to_uint64(carrier['x-b3-parentspanid'])
+          flags = parse_flags(carrier['x-b3-flags'], carrier['x-b3-sampled'])
+
+          return nil if span_id.nil? || trace_id.nil?
+          return nil if span_id.zero? || trace_id.zero?
+
+          SpanContext.new(
+            trace_id: trace_id,
+            parent_id: parent_id,
+            span_id: span_id,
+            flags: flags
+          )
+        end
+
+        # Extract a SpanContext from a given carrier in the Rack format
+        #
+        # @param carrier [Carrier] A carrier of type Rack
+        # @return [SpanContext] the extracted SpanContext or nil if none was extracted
+        def extract_rack(carrier)
+          trace_id = TraceId.base16_hex_id_to_uint64(carrier['HTTP_X_B3_TRACEID'])
+          span_id = TraceId.base16_hex_id_to_uint64(carrier['HTTP_X_B3_SPANID'])
+          parent_id = TraceId.base16_hex_id_to_uint64(carrier['HTTP_X_B3_PARENTSPANID'])
+          flags = parse_flags(carrier['HTTP_X_B3_FLAGS'], carrier['HTTP_X_B3_SAMPLED'])
+
+          return nil if span_id.nil? || trace_id.nil?
+          return nil if span_id.zero? || trace_id.zero?
+
+          SpanContext.new(
+            trace_id: trace_id,
+            parent_id: parent_id,
+            span_id: span_id,
+            flags: flags
+          )
+        end
+
+        private
+
+        # Convert an integer id into a 0 padded hex string.
+        # If the string is shorter than 16 characters, it will be padded to 16.
+        # If it is longer than 16 characters, it is padded to 32.
+        def to_hex(id)
+          hex_str = id.to_s(16)
+
+          # pad the string with '0's to 16 or 32 characters
+          if hex_str.length > 16
+            hex_str.rjust(32, '0')
+          else
+            hex_str.rjust(16, '0')
+          end
+        end
+
+        # if the flags header is '1' then the sampled header should not be present
+        def parse_flags(flags_header, sampled_header)
+          if flags_header == '1'
+            Jaeger::Client::SpanContext::Flags::DEBUG
+          else
+            TraceId.base16_hex_id_to_uint64(sampled_header)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/jaeger/client/propagation_codec/b3_codec.rb
+++ b/lib/jaeger/client/propagation_codec/b3_codec.rb
@@ -4,7 +4,6 @@ module Jaeger
   module Client
     module PropagationCodec
       class B3Codec
-
         # Inject a SpanContext into the given carrier
         #
         # @param span_context [SpanContext]
@@ -16,7 +15,7 @@ module Jaeger
 
           # flags (for debug) and sampled headers are mutually exclusive
           if span_context.flags == Jaeger::Client::SpanContext::Flags::DEBUG
-            carrier['x-b3-flags'] = "1"
+            carrier['x-b3-flags'] = '1'
           else
             carrier['x-b3-sampled'] = span_context.flags.to_s(16)
           end

--- a/lib/jaeger/client/propagation_codec/jaeger_codec.rb
+++ b/lib/jaeger/client/propagation_codec/jaeger_codec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Jaeger
+  module Client
+    module PropagationCodec
+      class JaegerCodec
+
+        # Inject a SpanContext into the given carrier
+        #
+        # @param span_context [SpanContext]
+        # @param carrier [carrier] A carrier object of type TEXT_MAP or RACK
+        def inject(span_context, carrier)
+          carrier['uber-trace-id'] = [
+            span_context.trace_id.to_s(16),
+            span_context.span_id.to_s(16),
+            span_context.parent_id.to_s(16),
+            span_context.flags.to_s(16)
+          ].join(':')
+        end
+
+        # Extract a SpanContext from a given carrier in the Text Map format
+        #
+        # @param carrier [Carrier] A carrier of type Text Map
+        # @return [SpanContext] the extracted SpanContext or nil if none was extracted
+        def extract_text_map(carrier)
+          parse_context(carrier['uber-trace-id'])
+        end
+
+        # Extract a SpanContext from a given carrier in the Rack format
+        #
+        # @param carrier [Carrier] A carrier of type Rack
+        # @return [SpanContext] the extracted SpanContext or nil if none was extracted
+        def extract_rack(carrier)
+          parse_context(carrier['HTTP_UBER_TRACE_ID'])
+        end
+
+        private
+
+        def parse_context(trace)
+          return nil if !trace || trace == ''
+
+          trace_arguments = trace.split(':').map(&TraceId.method(:base16_hex_id_to_uint64))
+          return nil if trace_arguments.size != 4
+
+          trace_id, span_id, parent_id, flags = trace_arguments
+          return nil if trace_id.zero? || span_id.zero?
+
+          SpanContext.new(
+            trace_id: trace_id,
+            parent_id: parent_id,
+            span_id: span_id,
+            flags: flags
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/jaeger/client/propagation_codec/jaeger_codec.rb
+++ b/lib/jaeger/client/propagation_codec/jaeger_codec.rb
@@ -4,7 +4,6 @@ module Jaeger
   module Client
     module PropagationCodec
       class JaegerCodec
-
         # Inject a SpanContext into the given carrier
         #
         # @param span_context [SpanContext]

--- a/lib/jaeger/client/propagation_codec/jaeger_codec.rb
+++ b/lib/jaeger/client/propagation_codec/jaeger_codec.rb
@@ -3,39 +3,43 @@
 module Jaeger
   module Client
     module PropagationCodec
-      class JaegerCodec
+      module JaegerCodec
         # Inject a SpanContext into the given carrier
         #
         # @param span_context [SpanContext]
         # @param carrier [carrier] A carrier object of type TEXT_MAP or RACK
-        def inject(span_context, carrier)
-          carrier['uber-trace-id'] = [
-            span_context.trace_id.to_s(16),
-            span_context.span_id.to_s(16),
-            span_context.parent_id.to_s(16),
-            span_context.flags.to_s(16)
-          ].join(':')
+        def self.inject(span_context, format, carrier)
+          case format
+          when OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_RACK
+            carrier['uber-trace-id'] = [
+              span_context.trace_id.to_s(16),
+              span_context.span_id.to_s(16),
+              span_context.parent_id.to_s(16),
+              span_context.flags.to_s(16)
+            ].join(':')
+          else
+            warn "Jaeger::Client with format #{format} is not supported yet"
+          end
         end
 
-        # Extract a SpanContext from a given carrier in the Text Map format
+        # Extract a SpanContext in the given format from the given carrier.
         #
-        # @param carrier [Carrier] A carrier of type Text Map
-        # @return [SpanContext] the extracted SpanContext or nil if none was extracted
-        def extract_text_map(carrier)
-          parse_context(carrier['uber-trace-id'])
+        # @param format [OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_BINARY, OpenTracing::FORMAT_RACK]
+        # @param carrier [Carrier] A carrier object of the type dictated by the specified `format`
+        # @return [SpanContext] the extracted SpanContext or nil if none could be found
+        def self.extract(format, carrier)
+          case format
+          when OpenTracing::FORMAT_TEXT_MAP
+            parse_context(carrier['uber-trace-id'])
+          when OpenTracing::FORMAT_RACK
+            parse_context(carrier['HTTP_UBER_TRACE_ID'])
+          else
+            warn "Jaeger::Client with format #{format} is not supported yet"
+            nil
+          end
         end
 
-        # Extract a SpanContext from a given carrier in the Rack format
-        #
-        # @param carrier [Carrier] A carrier of type Rack
-        # @return [SpanContext] the extracted SpanContext or nil if none was extracted
-        def extract_rack(carrier)
-          parse_context(carrier['HTTP_UBER_TRACE_ID'])
-        end
-
-        private
-
-        def parse_context(trace)
+        def self.parse_context(trace)
           return nil if !trace || trace == ''
 
           trace_arguments = trace.split(':').map(&TraceId.method(:base16_hex_id_to_uint64))

--- a/lib/jaeger/client/trace_id.rb
+++ b/lib/jaeger/client/trace_id.rb
@@ -22,6 +22,20 @@ module Jaeger
       def self.uint64_id_to_int64(id)
         id > MAX_64BIT_SIGNED_INT ? id - MAX_64BIT_UNSIGNED_INT - 1 : id
       end
+
+      # Convert an integer id into a 0 padded hex string.
+      # If the string is shorter than 16 characters, it will be padded to 16.
+      # If it is longer than 16 characters, it is padded to 32.
+      def self.to_hex(id)
+        hex_str = id.to_s(16)
+
+        # pad the string with '0's to 16 or 32 characters
+        if hex_str.length > 16
+          hex_str.rjust(32, '0')
+        else
+          hex_str.rjust(16, '0')
+        end
+      end
     end
   end
 end

--- a/lib/jaeger/client/tracer.rb
+++ b/lib/jaeger/client/tracer.rb
@@ -128,12 +128,7 @@ module Jaeger
       # @param format [OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_BINARY, OpenTracing::FORMAT_RACK]
       # @param carrier [Carrier] A carrier object of the type dictated by the specified `format`
       def inject(span_context, format, carrier)
-        case format
-        when OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_RACK
-          @propagation_codec.inject(span_context, carrier)
-        else
-          warn "Jaeger::Client with format #{format} is not supported yet"
-        end
+        @propagation_codec.inject(span_context, format, carrier)
       end
 
       # Extract a SpanContext in the given format from the given carrier.
@@ -142,15 +137,7 @@ module Jaeger
       # @param carrier [Carrier] A carrier object of the type dictated by the specified `format`
       # @return [SpanContext] the extracted SpanContext or nil if none could be found
       def extract(format, carrier)
-        case format
-        when OpenTracing::FORMAT_TEXT_MAP
-          @propagation_codec.extract_text_map(carrier)
-        when OpenTracing::FORMAT_RACK
-          @propagation_codec.extract_rack(carrier)
-        else
-          warn "Jaeger::Client with format #{format} is not supported yet"
-          nil
-        end
+        @propagation_codec.extract(format, carrier)
       end
 
       private

--- a/spec/jaeger/client/propagation_codec/b3_codec_spec.rb
+++ b/spec/jaeger/client/propagation_codec/b3_codec_spec.rb
@@ -1,0 +1,233 @@
+require 'spec_helper'
+
+describe Jaeger::Client::PropagationCodec::B3Codec do
+  let(:tracer) { Jaeger::Client::Tracer.new(reporter, sampler, codec) }
+  let(:reporter) { instance_spy(Jaeger::Client::AsyncReporter) }
+  let(:sampler) { Jaeger::Client::Samplers::Const.new(true) }
+  let (:codec) { described_class.new }
+
+  describe '#inject' do
+    let(:operation_name) { 'operator-name' }
+    let(:span) { tracer.start_span(operation_name) }
+    let(:span_context) { span.context }
+    let(:carrier) { {} }
+
+    context 'when FORMAT_TEXT_MAP' do
+      before { codec.inject(span_context, carrier) }
+
+      it 'sets trace information' do
+        expect(carrier['x-b3-traceid']).to eq(span_context.trace_id.to_s(16).rjust(16, '0'))
+        expect(carrier['x-b3-spanid']).to eq(span_context.span_id.to_s(16).rjust(16, '0'))
+        expect(carrier['x-b3-parentspanid']).to eq(span_context.parent_id.to_s(16).rjust(16, '0'))
+        expect(carrier['x-b3-sampled']).to eq(span_context.flags.to_s(16))
+      end
+    end
+
+    context 'when sampler flag is DEBUG' do
+      before do
+        # mock flags since the test tracer doesn't have this yet
+        allow(span_context).to receive(:flags).and_return(0x02)
+
+        codec.inject(span_context, carrier)
+      end
+
+      it 'sets the x-b3-flags header' do
+        expect(carrier).to have_key 'x-b3-flags'
+        expect(carrier['x-b3-flags']).to eq '1'
+      end
+
+      it 'does not set the x-b3-sampled header' do
+        expect(carrier).not_to have_key 'x-b3-sampled'
+      end
+    end
+
+    context 'when span context IDs are longer than 16 characters' do
+      before do
+        # mock fields, since they are read only
+        allow(span_context).to receive(:trace_id).and_return(0xFFFFFFFFFFFFFFFFF)
+        allow(span_context).to receive(:span_id).and_return(0xFFFFFFFFFFFFFFFFF)
+        allow(span_context).to receive(:parent_id).and_return(0xFFFFFFFFFFFFFFFFF)
+
+        codec.inject(span_context, carrier)
+      end
+
+      it 'pads the hex id strings to 32 characters' do
+        expect(carrier['x-b3-traceid'].length).to eq 32
+        expect(carrier['x-b3-spanid'].length).to eq 32
+        expect(carrier['x-b3-parentspanid'].length).to eq 32
+      end
+
+    end
+  end
+
+  context 'when extracting' do
+    let(:hexa_max_uint64) { 'ff' * 8 }
+    let(:max_uint64) { 2**64 - 1 }
+
+    let(:operation_name) { 'operator-name' }
+    let(:trace_id) { '58a515c97fd61fd7' }
+    let(:parent_id) { '8e5a8c5509c8dcc1' }
+    let(:span_id) { 'aba8be8d019abed2' }
+    let(:flags) { '1' }
+
+    describe '#extract_text_map' do
+      context 'when header x-b3-sampled is present' do
+        let(:carrier) { Net::HTTPResponse.new({}, 200, "") }
+
+        before do
+          carrier['x-b3-traceid'] = trace_id
+          carrier['x-b3-spanid'] = span_id
+          carrier['x-b3-parentspanid'] = parent_id
+          carrier['x-b3-sampled'] = flags
+        end
+
+        let(:span_context) { codec.extract_text_map(carrier) }
+
+        it 'has flags' do
+          expect(span_context.flags).to eq(flags.to_i(16))
+        end
+
+        context 'when trace-id is a max uint64' do
+          let(:trace_id) { hexa_max_uint64 }
+
+          it 'interprets it correctly' do
+            expect(span_context.trace_id).to eq(max_uint64)
+          end
+        end
+
+        context 'when parent-id is a max uint64' do
+          let(:parent_id) { hexa_max_uint64 }
+
+          it 'interprets it correctly' do
+            expect(span_context.parent_id).to eq(max_uint64)
+          end
+        end
+
+        context 'when span-id is a max uint64' do
+          let(:span_id) { hexa_max_uint64 }
+
+          it 'interprets it correctly' do
+            expect(span_context.span_id).to eq(max_uint64)
+          end
+        end
+
+        context 'when parent-id is 0' do
+          let(:parent_id) { '0' }
+
+          it 'sets parent_id to 0' do
+            expect(span_context.parent_id).to eq(0)
+          end
+        end
+
+        context 'when trace-id missing' do
+          let(:trace_id) { nil }
+
+          it 'returns nil' do
+            expect(span_context).to eq(nil)
+          end
+        end
+
+        context 'when span-id missing' do
+          let(:span_id) { nil }
+
+          it 'returns nil' do
+            expect(span_context).to eq(nil)
+          end
+        end
+      end
+
+      context 'when header x-b3-flags is present' do
+        let(:carrier) { Net::HTTPResponse.new({}, 200, "") }
+
+        before do
+          carrier['x-b3-traceid'] = trace_id
+          carrier['x-b3-spanid'] = span_id
+          carrier['x-b3-parentspanid'] = parent_id
+          carrier['x-b3-flags'] = '1'
+        end
+
+        let(:span_context) { codec.extract_text_map(carrier) }
+
+        it 'sets the DEBUG flag' do
+          expect(span_context.flags).to eq(0x02)
+        end
+      end
+    end
+
+    describe '#extract_rack' do
+      context 'when header HTTP_X_B3_SAMPLED is present' do
+        let(:carrier) { { 'HTTP_X_B3_TRACEID' => trace_id,
+                          'HTTP_X_B3_SPANID' => span_id,
+                          'HTTP_X_B3_PARENTSPANID' => parent_id,
+                          'HTTP_X_B3_SAMPLED' => flags } }
+
+        let(:span_context) { codec.extract_rack(carrier) }
+
+        it 'has flags' do
+          expect(span_context.flags).to eq(flags.to_i(16))
+        end
+
+        context 'when trace-id is a max uint64' do
+          let(:trace_id) { hexa_max_uint64 }
+
+          it 'interprets it correctly' do
+            expect(span_context.trace_id).to eq(max_uint64)
+          end
+        end
+
+        context 'when parent-id is a max uint64' do
+          let(:parent_id) { hexa_max_uint64 }
+
+          it 'interprets it correctly' do
+            expect(span_context.parent_id).to eq(max_uint64)
+          end
+        end
+
+        context 'when span-id is a max uint64' do
+          let(:span_id) { hexa_max_uint64 }
+
+          it 'interprets it correctly' do
+            expect(span_context.span_id).to eq(max_uint64)
+          end
+        end
+
+        context 'when parent-id is 0' do
+          let(:parent_id) { '0' }
+
+          it 'sets parent_id to 0' do
+            expect(span_context.parent_id).to eq(0)
+          end
+        end
+
+        context 'when trace-id is missing' do
+          let(:trace_id) { nil }
+
+          it 'returns nil' do
+            expect(span_context).to eq(nil)
+          end
+        end
+
+        context 'when span-id is missing' do
+          let(:span_id) { nil }
+
+          it 'returns nil' do
+            expect(span_context).to eq(nil)
+          end
+        end
+      end
+
+      context 'when header HTTP_X_B3_FLAGS is present' do
+        let(:carrier) { { 'HTTP_X_B3_TRACEID' => trace_id,
+                          'HTTP_X_B3_SPANID' => span_id,
+                          'HTTP_X_B3_PARENTSPANID' => parent_id,
+                          'HTTP_X_B3_FLAGS' => '1' } }
+
+        let(:span_context) { codec.extract_rack(carrier) }
+
+        it 'sets the DEBUG flag' do
+          expect(span_context.flags).to eq(0x02)
+        end
+      end
+    end
+  end
+end

--- a/spec/jaeger/client/propagation_codec/jaeger_codec_spec.rb
+++ b/spec/jaeger/client/propagation_codec/jaeger_codec_spec.rb
@@ -1,0 +1,155 @@
+require 'spec_helper'
+
+describe Jaeger::Client::PropagationCodec::JaegerCodec do
+  let(:tracer) { Jaeger::Client::Tracer.new(reporter, sampler, codec) }
+  let(:reporter) { instance_spy(Jaeger::Client::AsyncReporter) }
+  let(:sampler) { Jaeger::Client::Samplers::Const.new(true) }
+  let (:codec) { described_class.new }
+
+  describe '#inject' do
+    let(:operation_name) { 'operator-name' }
+    let(:span) { tracer.start_span(operation_name) }
+    let(:span_context) { span.context }
+    let(:carrier) { {} }
+
+    context 'when FORMAT_TEXT_MAP' do
+      before { codec.inject(span_context, carrier) }
+
+      it 'sets trace information' do
+        expect(carrier['uber-trace-id']).to eq(
+          [
+            span_context.trace_id.to_s(16),
+            span_context.span_id.to_s(16),
+            span_context.parent_id.to_s(16),
+            span_context.flags.to_s(16)
+          ].join(':')
+        )
+      end
+    end
+  end
+
+  context 'when extracting' do
+    let(:hexa_max_uint64) { 'ff' * 8 }
+    let(:max_uint64) { 2**64 - 1 }
+
+    let(:operation_name) { 'operator-name' }
+    let(:trace_id) { '58a515c97fd61fd7' }
+    let(:parent_id) { '8e5a8c5509c8dcc1' }
+    let(:span_id) { 'aba8be8d019abed2' }
+    let(:flags) { '1' }
+
+    describe '#extract_text_map' do
+      let(:carrier) { { 'uber-trace-id' => "#{trace_id}:#{span_id}:#{parent_id}:#{flags}" } }
+      let(:span_context) { codec.extract_text_map(carrier) }
+
+      it 'has flags' do
+        expect(span_context.flags).to eq(flags.to_i(16))
+      end
+
+      context 'when trace-id is a max uint64' do
+        let(:trace_id) { hexa_max_uint64 }
+
+        it 'interprets it correctly' do
+          expect(span_context.trace_id).to eq(max_uint64)
+        end
+      end
+
+      context 'when parent-id is a max uint64' do
+        let(:parent_id) { hexa_max_uint64 }
+
+        it 'interprets it correctly' do
+          expect(span_context.parent_id).to eq(max_uint64)
+        end
+      end
+
+      context 'when span-id is a max uint64' do
+        let(:span_id) { hexa_max_uint64 }
+
+        it 'interprets it correctly' do
+          expect(span_context.span_id).to eq(max_uint64)
+        end
+      end
+
+      context 'when parent-id is 0' do
+        let(:parent_id) { '0' }
+
+        it 'sets parent_id to 0' do
+          expect(span_context.parent_id).to eq(0)
+        end
+      end
+
+      context 'when trace-id missing' do
+        let(:trace_id) { nil }
+
+        it 'returns nil' do
+          expect(span_context).to eq(nil)
+        end
+      end
+
+      context 'when span-id missing' do
+        let(:span_id) { nil }
+
+        it 'returns nil' do
+          expect(span_context).to eq(nil)
+        end
+      end
+    end
+
+    describe '#extract_rack' do
+      let(:carrier) { { 'HTTP_UBER_TRACE_ID' => "#{trace_id}:#{span_id}:#{parent_id}:#{flags}" } }
+      let(:span_context) { codec.extract_rack(carrier) }
+
+      it 'has flags' do
+        expect(span_context.flags).to eq(flags.to_i(16))
+      end
+
+      context 'when trace-id is a max uint64' do
+        let(:trace_id) { hexa_max_uint64 }
+
+        it 'interprets it correctly' do
+          expect(span_context.trace_id).to eq(max_uint64)
+        end
+      end
+
+      context 'when parent-id is a max uint64' do
+        let(:parent_id) { hexa_max_uint64 }
+
+        it 'interprets it correctly' do
+          expect(span_context.parent_id).to eq(max_uint64)
+        end
+      end
+
+      context 'when span-id is a max uint64' do
+        let(:span_id) { hexa_max_uint64 }
+
+        it 'interprets it correctly' do
+          expect(span_context.span_id).to eq(max_uint64)
+        end
+      end
+
+      context 'when parent-id is 0' do
+        let(:parent_id) { '0' }
+
+        it 'sets parent_id to 0' do
+          expect(span_context.parent_id).to eq(0)
+        end
+      end
+
+      context 'when trace-id is missing' do
+        let(:trace_id) { nil }
+
+        it 'returns nil' do
+          expect(span_context).to eq(nil)
+        end
+      end
+
+      context 'when span-id is missing' do
+        let(:span_id) { nil }
+
+        it 'returns nil' do
+          expect(span_context).to eq(nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/jaeger/client/propagation_codec/jaeger_codec_spec.rb
+++ b/spec/jaeger/client/propagation_codec/jaeger_codec_spec.rb
@@ -4,7 +4,7 @@ describe Jaeger::Client::PropagationCodec::JaegerCodec do
   let(:tracer) { Jaeger::Client::Tracer.new(reporter, sampler, codec) }
   let(:reporter) { instance_spy(Jaeger::Client::AsyncReporter) }
   let(:sampler) { Jaeger::Client::Samplers::Const.new(true) }
-  let (:codec) { described_class.new }
+  let(:codec) { described_class.new }
 
   describe '#inject' do
     let(:operation_name) { 'operator-name' }

--- a/spec/jaeger/client/propagation_codec/jaeger_codec_spec.rb
+++ b/spec/jaeger/client/propagation_codec/jaeger_codec_spec.rb
@@ -4,7 +4,7 @@ describe Jaeger::Client::PropagationCodec::JaegerCodec do
   let(:tracer) { Jaeger::Client::Tracer.new(reporter, sampler, codec) }
   let(:reporter) { instance_spy(Jaeger::Client::AsyncReporter) }
   let(:sampler) { Jaeger::Client::Samplers::Const.new(true) }
-  let(:codec) { described_class.new }
+  let(:codec) { described_class }
 
   describe '#inject' do
     let(:operation_name) { 'operator-name' }
@@ -13,7 +13,7 @@ describe Jaeger::Client::PropagationCodec::JaegerCodec do
     let(:carrier) { {} }
 
     context 'when FORMAT_TEXT_MAP' do
-      before { codec.inject(span_context, carrier) }
+      before { codec.inject(span_context, OpenTracing::FORMAT_TEXT_MAP, carrier) }
 
       it 'sets trace information' do
         expect(carrier['uber-trace-id']).to eq(
@@ -40,7 +40,7 @@ describe Jaeger::Client::PropagationCodec::JaegerCodec do
 
     describe '#extract_text_map' do
       let(:carrier) { { 'uber-trace-id' => "#{trace_id}:#{span_id}:#{parent_id}:#{flags}" } }
-      let(:span_context) { codec.extract_text_map(carrier) }
+      let(:span_context) { codec.extract(OpenTracing::FORMAT_TEXT_MAP, carrier) }
 
       it 'has flags' do
         expect(span_context.flags).to eq(flags.to_i(16))
@@ -97,7 +97,7 @@ describe Jaeger::Client::PropagationCodec::JaegerCodec do
 
     describe '#extract_rack' do
       let(:carrier) { { 'HTTP_UBER_TRACE_ID' => "#{trace_id}:#{span_id}:#{parent_id}:#{flags}" } }
-      let(:span_context) { codec.extract_rack(carrier) }
+      let(:span_context) { codec.extract(OpenTracing::FORMAT_RACK, carrier) }
 
       it 'has flags' do
         expect(span_context.flags).to eq(flags.to_i(16))

--- a/spec/jaeger/client/tracer_spec.rb
+++ b/spec/jaeger/client/tracer_spec.rb
@@ -4,7 +4,8 @@ describe Jaeger::Client::Tracer do
   let(:tracer) { described_class.new(reporter, sampler, codec) }
   let(:reporter) { instance_spy(Jaeger::Client::AsyncReporter) }
   let(:sampler) { Jaeger::Client::Samplers::Const.new(true) }
-  let(:codec) { instance_spy(Jaeger::Client::PropagationCodec::JaegerCodec) }
+  # let(:codec) { instance_spy(Jaeger::Client::PropagationCodec::JaegerCodec) }
+  let(:codec) { class_spy(Jaeger::Client::PropagationCodec::JaegerCodec) }
 
   describe '#start_span' do
     let(:operation_name) { 'operator-name' }
@@ -196,8 +197,8 @@ describe Jaeger::Client::Tracer do
 
       before { tracer.extract(OpenTracing::FORMAT_TEXT_MAP, carrier) }
 
-      it 'calls #extract_text_map on codec' do
-        expect(codec).to have_received(:extract_text_map)
+      it 'calls #extract' do
+        expect(codec).to have_received(:extract)
       end
     end
 
@@ -206,8 +207,8 @@ describe Jaeger::Client::Tracer do
 
       before { tracer.extract(OpenTracing::FORMAT_RACK, carrier) }
 
-      it 'calls #extract_rack on codec' do
-        expect(codec).to have_received(:extract_rack)
+      it 'calls #extract' do
+        expect(codec).to have_received(:extract)
       end
     end
   end


### PR DESCRIPTION
This adds support for Zipkin B3 propagation to the ruby client. Both the injection and extraction in B3 have been tested with services and tracing clients in other languages.

By default it still uses the Uber propagation scheme, which has been extracted out into `jaeger/client/propagation_codec/jaeger_codec.rb` but otherwise left unchanged.

When `propagate_b3` is passed to the client builder, the inject/extract logic in `jaeger/client/propagation_codec/b3_codec.rb` is used instead.