### PR TITLE
Move inject & extract logic to their own classes

### DIFF
--- a/lib/jaeger/client.rb
+++ b/lib/jaeger/client.rb
@@ -17,6 +17,12 @@ require_relative 'client/udp_sender'
 require_relative 'client/async_reporter'
 require_relative 'client/version'
 require_relative 'client/samplers'
+require_relative 'client/extractor'
+require_relative 'client/extractor/base'
+require_relative 'client/extractor/rack'
+require_relative 'client/extractor/text_map'
+require_relative 'client/injector'
+require_relative 'client/injector/text_map'
 require_relative 'client/encoders/thrift_encoder'
 
 module Jaeger

--- a/lib/jaeger/client/extractor.rb
+++ b/lib/jaeger/client/extractor.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Jaeger
+  module Client
+    class Extractor
+      class << self
+        def register(format, klass)
+          extractors[format] = klass
+        end
+
+        def extract(format, carrier)
+          if extractors[format]
+            extractors[format].extract(carrier)
+          else
+            warn "Jaeger::Client with format #{format} is not supported yet"
+            nil
+          end
+        end
+
+        def extractors
+          @extractors ||= {}
+        end
+      end
+    end
+  end
+end

--- a/lib/jaeger/client/extractor/base.rb
+++ b/lib/jaeger/client/extractor/base.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Jaeger
+  module Client
+    class Extractor
+      class Base
+        class << self
+          private
+
+          def parse_context(trace)
+            return nil if !trace || trace == ''
+
+            trace_arguments = trace.split(':').map(&TraceId.method(:base16_hex_id_to_uint64))
+            return nil if trace_arguments.size != 4
+
+            trace_id, span_id, parent_id, flags = trace_arguments
+            return nil if trace_id.zero? || span_id.zero?
+
+            SpanContext.new(
+              trace_id: trace_id,
+              parent_id: parent_id,
+              span_id: span_id,
+              flags: flags
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/jaeger/client/extractor/rack.rb
+++ b/lib/jaeger/client/extractor/rack.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Jaeger
+  module Client
+    class Extractor
+      class Rack < Base
+        class << self
+          def extract(carrier)
+            parse_context(carrier['HTTP_UBER_TRACE_ID'])
+          end
+        end
+      end
+    end
+  end
+end
+
+Jaeger::Client::Extractor.register(OpenTracing::FORMAT_RACK,
+                                   Jaeger::Client::Extractor::Rack)

--- a/lib/jaeger/client/extractor/text_map.rb
+++ b/lib/jaeger/client/extractor/text_map.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Jaeger
+  module Client
+    class Extractor
+      class TextMap < Base
+        class << self
+          def extract(carrier)
+            parse_context(carrier['uber-trace-id'])
+          end
+        end
+      end
+    end
+  end
+end
+
+Jaeger::Client::Extractor.register(OpenTracing::FORMAT_TEXT_MAP,
+                                   Jaeger::Client::Extractor::TextMap)

--- a/lib/jaeger/client/injector.rb
+++ b/lib/jaeger/client/injector.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Jaeger
+  module Client
+    class Injector
+      class << self
+        def register(format, klass)
+          injectors[format] = klass
+        end
+
+        def inject(span_context, format, carrier)
+          if injectors[format]
+            injectors[format].inject(span_context, carrier)
+          else
+            warn "Jaeger::Client with format #{format} is not supported yet"
+          end
+        end
+
+        def injectors
+          @injectors ||= {}
+        end
+      end
+    end
+  end
+end

--- a/lib/jaeger/client/injector/text_map.rb
+++ b/lib/jaeger/client/injector/text_map.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Jaeger
+  module Client
+    class Injector
+      class TextMap
+        class << self
+          def inject(span_context, carrier)
+            carrier['uber-trace-id'] = [
+              span_context.trace_id.to_s(16),
+              span_context.span_id.to_s(16),
+              span_context.parent_id.to_s(16),
+              span_context.flags.to_s(16)
+            ].join(':')
+          end
+        end
+      end
+    end
+  end
+end
+
+Jaeger::Client::Injector.register(OpenTracing::FORMAT_TEXT_MAP,
+                                  Jaeger::Client::Injector::TextMap)
+Jaeger::Client::Injector.register(OpenTracing::FORMAT_RACK,
+                                  Jaeger::Client::Injector::TextMap)

--- a/lib/jaeger/client/tracer.rb
+++ b/lib/jaeger/client/tracer.rb
@@ -127,17 +127,7 @@ module Jaeger
       # @param format [OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_BINARY, OpenTracing::FORMAT_RACK]
       # @param carrier [Carrier] A carrier object of the type dictated by the specified `format`
       def inject(span_context, format, carrier)
-        case format
-        when OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_RACK
-          carrier['uber-trace-id'] = [
-            span_context.trace_id.to_s(16),
-            span_context.span_id.to_s(16),
-            span_context.parent_id.to_s(16),
-            span_context.flags.to_s(16)
-          ].join(':')
-        else
-          warn "Jaeger::Client with format #{format} is not supported yet"
-        end
+        Injector.inject(span_context, format, carrier)
       end
 
       # Extract a SpanContext in the given format from the given carrier.
@@ -146,35 +136,10 @@ module Jaeger
       # @param carrier [Carrier] A carrier object of the type dictated by the specified `format`
       # @return [SpanContext] the extracted SpanContext or nil if none could be found
       def extract(format, carrier)
-        case format
-        when OpenTracing::FORMAT_TEXT_MAP
-          parse_context(carrier['uber-trace-id'])
-        when OpenTracing::FORMAT_RACK
-          parse_context(carrier['HTTP_UBER_TRACE_ID'])
-        else
-          warn "Jaeger::Client with format #{format} is not supported yet"
-          nil
-        end
+        Extractor.extract(format, carrier)
       end
 
       private
-
-      def parse_context(trace)
-        return nil if !trace || trace == ''
-
-        trace_arguments = trace.split(':').map(&TraceId.method(:base16_hex_id_to_uint64))
-        return nil if trace_arguments.size != 4
-
-        trace_id, span_id, parent_id, flags = trace_arguments
-        return nil if trace_id.zero? || span_id.zero?
-
-        SpanContext.new(
-          trace_id: trace_id,
-          parent_id: parent_id,
-          span_id: span_id,
-          flags: flags
-        )
-      end
 
       def prepare_span_context(child_of:, references:, ignore_active_scope:)
         context =

--- a/spec/jaeger/client/extractor/rack_spec.rb
+++ b/spec/jaeger/client/extractor/rack_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+RSpec.describe Jaeger::Client::Extractor::Rack do
+  let(:hexa_max_uint64) { 'ff' * 8 }
+  let(:max_uint64) { 2**64 - 1 }
+
+  let(:operation_name) { 'operator-name' }
+  let(:trace_id) { '58a515c97fd61fd7' }
+  let(:parent_id) { '8e5a8c5509c8dcc1' }
+  let(:span_id) { 'aba8be8d019abed2' }
+  let(:flags) { '1' }
+
+  describe '::extract' do
+    let(:carrier) { { 'HTTP_UBER_TRACE_ID' => "#{trace_id}:#{span_id}:#{parent_id}:#{flags}" } }
+    let(:span_context) { described_class.extract(carrier) }
+
+    it 'has flags' do
+      expect(span_context.flags).to eq(flags.to_i(16))
+    end
+
+    context 'when trace-id is a max uint64' do
+      let(:trace_id) { hexa_max_uint64 }
+
+      it 'interprets it correctly' do
+        expect(span_context.trace_id).to eq(max_uint64)
+      end
+    end
+
+    context 'when parent-id is a max uint64' do
+      let(:parent_id) { hexa_max_uint64 }
+
+      it 'interprets it correctly' do
+        expect(span_context.parent_id).to eq(max_uint64)
+      end
+    end
+
+    context 'when span-id is a max uint64' do
+      let(:span_id) { hexa_max_uint64 }
+
+      it 'interprets it correctly' do
+        expect(span_context.span_id).to eq(max_uint64)
+      end
+    end
+
+    context 'when parent-id is 0' do
+      let(:parent_id) { '0' }
+
+      it 'sets parent_id to 0' do
+        expect(span_context.parent_id).to eq(0)
+      end
+    end
+
+    context 'when trace-id is missing' do
+      let(:trace_id) { nil }
+
+      it 'returns nil' do
+        expect(span_context).to eq(nil)
+      end
+    end
+
+    context 'when span-id is missing' do
+      let(:span_id) { nil }
+
+      it 'returns nil' do
+        expect(span_context).to eq(nil)
+      end
+    end
+  end
+end

--- a/spec/jaeger/client/extractor/text_map_spec.rb
+++ b/spec/jaeger/client/extractor/text_map_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+RSpec.describe Jaeger::Client::Extractor::TextMap do
+  let(:hexa_max_uint64) { 'ff' * 8 }
+  let(:max_uint64) { 2**64 - 1 }
+
+  let(:operation_name) { 'operator-name' }
+  let(:trace_id) { '58a515c97fd61fd7' }
+  let(:parent_id) { '8e5a8c5509c8dcc1' }
+  let(:span_id) { 'aba8be8d019abed2' }
+  let(:flags) { '1' }
+
+  describe '::extract' do
+    let(:carrier) { { 'uber-trace-id' => "#{trace_id}:#{span_id}:#{parent_id}:#{flags}" } }
+    let(:span_context) { described_class.extract(carrier) }
+
+    it 'has flags' do
+      expect(span_context.flags).to eq(flags.to_i(16))
+    end
+
+    context 'when trace-id is a max uint64' do
+      let(:trace_id) { hexa_max_uint64 }
+
+      it 'interprets it correctly' do
+        expect(span_context.trace_id).to eq(max_uint64)
+      end
+    end
+
+    context 'when parent-id is a max uint64' do
+      let(:parent_id) { hexa_max_uint64 }
+
+      it 'interprets it correctly' do
+        expect(span_context.parent_id).to eq(max_uint64)
+      end
+    end
+
+    context 'when span-id is a max uint64' do
+      let(:span_id) { hexa_max_uint64 }
+
+      it 'interprets it correctly' do
+        expect(span_context.span_id).to eq(max_uint64)
+      end
+    end
+
+    context 'when parent-id is 0' do
+      let(:parent_id) { '0' }
+
+      it 'sets parent_id to 0' do
+        expect(span_context.parent_id).to eq(0)
+      end
+    end
+
+    context 'when trace-id missing' do
+      let(:trace_id) { nil }
+
+      it 'returns nil' do
+        expect(span_context).to eq(nil)
+      end
+    end
+
+    context 'when span-id missing' do
+      let(:span_id) { nil }
+
+      it 'returns nil' do
+        expect(span_context).to eq(nil)
+      end
+    end
+  end
+end

--- a/spec/jaeger/client/extractor_spec.rb
+++ b/spec/jaeger/client/extractor_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+RSpec.describe Jaeger::Client::Extractor do
+  describe '::register' do
+    let(:extractor) { Class.new }
+    let(:format) { 'FOO' }
+
+    it 'registers new extractor with given format' do
+      expect { described_class.register(format, extractor) }
+        .to change { described_class.extractors[format] }
+        .from(nil).to(extractor)
+    end
+  end
+
+  describe '::extract' do
+    context 'when there is an extractor for given format' do
+      let(:extractor) { spy }
+      let(:format) { 'BAR' }
+      let(:carrier) { {} }
+
+      before do
+        described_class.register(format, extractor)
+      end
+
+      it 'delegates the call to extractor of format' do
+        described_class.extract(format, carrier)
+
+        expect(extractor).to have_received(:extract).with(carrier).once
+      end
+    end
+
+    context 'when there is no extractor for given format' do
+      before { allow(described_class).to receive(:warn) }
+
+      it 'puts a warning message' do
+        described_class.extract('UNKNOWN_FORMAT', {})
+
+        expect(described_class).to have_received(:warn)
+      end
+    end
+  end
+end

--- a/spec/jaeger/client/injector/text_map_spec.rb
+++ b/spec/jaeger/client/injector/text_map_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe Jaeger::Client::Injector::TextMap do
+  describe '#inject' do
+    let(:carrier) { {} }
+    let(:expected_trace_id) { '1:3:2:0' }
+    let(:span_context) do
+      Jaeger::Client::SpanContext.new(
+        trace_id: 1,
+        parent_id: 2,
+        span_id: 3,
+        flags: 0x00
+      )
+    end
+
+    it 'sets trace information' do
+      expect { described_class.inject(span_context, carrier) }
+        .to change { carrier['uber-trace-id'] }
+        .from(nil)
+        .to(expected_trace_id)
+    end
+  end
+end

--- a/spec/jaeger/client/injector_spec.rb
+++ b/spec/jaeger/client/injector_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+RSpec.describe Jaeger::Client::Injector do
+  describe '::register' do
+    let(:injector) { Class.new }
+    let(:format) { 'FOO' }
+
+    it 'registers new injector with given format' do
+      expect { described_class.register(format, injector) }
+        .to change { described_class.injectors[format] }
+        .from(nil).to(injector)
+    end
+  end
+
+  describe '::inject' do
+    let(:span_context) do
+      Jaeger::Client::SpanContext.new(
+        trace_id: 'trace-id',
+        parent_id: nil,
+        span_id: 'span-id',
+        flags: 0x00
+      )
+    end
+
+    context 'when there is an injector for given format' do
+      let(:injector) { spy }
+      let(:format) { 'BAR' }
+      let(:carrier) { {} }
+
+      before do
+        described_class.register(format, injector)
+      end
+
+      it 'delegates the call to injector of format' do
+        described_class.inject(span_context, format, carrier)
+
+        expect(injector).to have_received(:inject).with(span_context, carrier)
+      end
+    end
+
+    context 'when there is no injector for given format' do
+      before { allow(described_class).to receive(:warn) }
+
+      it 'puts a warning message' do
+        described_class.inject(span_context, 'UNKNOWN_FORMAT', {})
+
+        expect(described_class).to have_received(:warn)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Injecting and extracting trace IDs have been moved to their own classes
and DSL implemented to register injectors and extractors.