### PR TITLE
Fix reporter thread creation

### DIFF
--- a/spec/jaeger/client/async_reporter_spec.rb
+++ b/spec/jaeger/client/async_reporter_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Jaeger::Client::AsyncReporter do
-  let(:reporter) { described_class.new(sender) }
+  let(:reporter) { described_class.new(sender, 1) }
   let(:sender) { spy }
   let(:operation_name) { 'op-name' }
 

--- a/spec/jaeger/client/async_reporter_spec.rb
+++ b/spec/jaeger/client/async_reporter_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Jaeger::Client::AsyncReporter do
   let(:sender) { spy }
   let(:operation_name) { 'op-name' }
 
+  before { allow(Thread).to receive(:new) }
+
   describe '#report' do
     let(:context) do
       Jaeger::Client::SpanContext.new(


### PR DESCRIPTION
Reporter thread does not work if you fork another process after initialising the tracer. This pr fixes this behaviour.

An example script would be;
```ruby
SLEEP_FOR = 5
OpenTracing.global_tracer = Jaeger::Client.build(service_name: 'TEST')

def send_span
  scope = OpenTracing.global_tracer.start_active_span("TEST SPAN FROM #{Process.pid}")
  scope.close
end

pid = fork do
  loop do
    send_span
    sleep(SLEEP_FOR)
  end
end

loop do
  send_span
  sleep(SLEEP_FOR)
end
```

With this implementation the `AsyncReporter#create` factory method can(should) be removed.