### PR TITLE
Include URL to source code in gemspec

### DIFF
--- a/jaeger-client.gemspec
+++ b/jaeger-client.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = 'OpenTracing Tracer implementation for Jaeger in Ruby'
   spec.description   = ''
-  spec.homepage      = ''
+  spec.homepage      = 'https://github.com/salemove/jaeger-client-ruby'
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
Should allow to navigate more easily from https://rubygems.org/gems/jaeger-client to the source code repository.
This helps humans and bots along, e.g. https://depfu.com/ should be able to provide more useful dependency update PRs with links to changes between versions.