### PR TITLE
Add mechanism to limit UDP message batch size

### DIFF
--- a/lib/jaeger/encoders/thrift_encoder.rb
+++ b/lib/jaeger/encoders/thrift_encoder.rb
@@ -6,6 +6,7 @@ module Jaeger
       def initialize(service_name:, tags: {})
         @service_name = service_name
         @tags = prepare_tags(tags)
+        @process = Jaeger::Thrift::Process.new('serviceName' => @service_name, 'tags' => @tags)
       end
 
       def encode(spans)
@@ -34,7 +35,7 @@ module Jaeger
       private
 
       def encode_batch(encoded_spans)
-        Jaeger::Thrift::Batch.new('process' => Jaeger::Thrift::Process.new('serviceName' => @service_name, 'tags' => @tags), 'spans' => encoded_spans)
+        Jaeger::Thrift::Batch.new('process' => @process, 'spans' => encoded_spans)
       end
 
       def encode_span(span)

--- a/lib/jaeger/encoders/thrift_encoder.rb
+++ b/lib/jaeger/encoders/thrift_encoder.rb
@@ -9,16 +9,33 @@ module Jaeger
       end
 
       def encode(spans)
-        Jaeger::Thrift::Batch.new(
-          'process' => Jaeger::Thrift::Process.new(
-            'serviceName' => @service_name,
-            'tags' => @tags
-          ),
-          'spans' => spans.map(&method(:encode_span))
-        )
+        encode_batch(spans.map(&method(:encode_span)))
+      end
+
+      def encode_limited_size(spans, protocol_class, max_message_length)
+        batches = []
+        current_batch = []
+        current_batch_size = 0
+        spans.each do |span|
+          encoded_span = encode_span(span)
+          encoded_span_size = span_byte_length(encoded_span, protocol_class)
+          if encoded_span_size + current_batch_size > max_message_length && !current_batch.empty?
+            batches << encode_batch(current_batch)
+            current_batch = []
+            current_batch_size = 0
+          end
+          current_batch << encoded_span
+          current_batch_size += encoded_span_size
+        end
+        batches << encode_batch(current_batch) unless current_batch.empty?
+        batches
       end
 
       private
+
+      def encode_batch(encoded_spans)
+        Jaeger::Thrift::Batch.new('process' => Jaeger::Thrift::Process.new('serviceName' => @service_name, 'tags' => @tags), 'spans' => encoded_spans)
+      end
 
       def encode_span(span)
         context = span.context
@@ -82,6 +99,25 @@ module Jaeger
         with_default_tags.map do |key, value|
           ThriftTagBuilder.build(key, value)
         end
+      end
+
+      class DummyTransport
+        attr_accessor :size
+        def initialize
+          @size = 0
+        end
+        def write(buf)
+          @size += buf.size
+        end
+        def flush; end
+        def close; end
+      end
+
+      def span_byte_length(span, protocol_class)
+        transport = DummyTransport.new
+        protocol = protocol_class.new(transport)
+        span.write(protocol)
+        transport.size
       end
     end
   end

--- a/lib/jaeger/extractors.rb
+++ b/lib/jaeger/extractors.rb
@@ -57,8 +57,25 @@ module Jaeger
     end
 
     class JaegerBinaryCodec
-      def self.extract(_carrier)
-        warn 'Jaeger::Client with binary format is not supported yet'
+      def self.extract(carrier)
+        header_size = 16 + 8 + 8 + 1
+        trace_id_hi, trace_id_lo, span_id, parent_id, flags = carrier[0...header_size].unpack("Q>Q>Q>Q>C")
+        context = SpanContext.new(trace_id: trace_id_lo, parent_id: parent_id, span_id: span_id, flags: flags)
+
+        parse_pointer = header_size
+        while parse_pointer < carrier.size do
+          key_size = carrier[parse_pointer...(parse_pointer + 4)].unpack("L>")
+          parser_pointer += 4
+          key = carrier[parser_pointer...(parser_pointer + key_size)]
+          parser_pointer += key_size
+          value_size = carrier[parse_pointer...(parse_pointer + 4)].unpack("L>")
+          parser_pointer += 4
+          value = carrier[parser_pointer...(parser_pointer + value_size)]
+          parser_pointer += value_size
+          context.set_baggage_item(key, value)
+        end
+
+        context
       end
     end
 

--- a/lib/jaeger/injectors.rb
+++ b/lib/jaeger/injectors.rb
@@ -31,8 +31,15 @@ module Jaeger
     end
 
     class JaegerBinaryCodec
-      def self.inject(_span_context, _carrier)
-        warn 'Jaeger::Client with binary format is not supported yet'
+      def self.inject(span_context, carrier)
+        carrier.clear
+        carrier << [0, span_context.trace_id, span_context.span_id, span_context.parent_id, span_context.flags].pack("Q>Q>Q>Q>C")
+        span_context.baggage.each do |key, value|
+          carrier << [key.size].pack("L>")
+          carrier << key.to_s
+          carrier << [value.size].pack("L>")
+          carrier << value.to_s
+        end
       end
     end
 

--- a/lib/jaeger/injectors.rb
+++ b/lib/jaeger/injectors.rb
@@ -35,10 +35,10 @@ module Jaeger
         carrier.clear
         carrier << [0, span_context.trace_id, span_context.span_id, span_context.parent_id, span_context.flags].pack("Q>Q>Q>Q>C")
         span_context.baggage.each do |key, value|
-          carrier << [key.size].pack("L>")
-          carrier << key.to_s
-          carrier << [value.size].pack("L>")
-          carrier << value.to_s
+          carrier << [key.bytesize].pack("L>")
+          carrier << key
+          carrier << [value.bytesize].pack("L>")
+          carrier << value
         end
       end
     end

--- a/lib/jaeger/udp_sender.rb
+++ b/lib/jaeger/udp_sender.rb
@@ -5,7 +5,7 @@ require 'socket'
 
 module Jaeger
   class UdpSender
-    def initialize(host:, port:, encoder:, logger:)
+    def initialize(host:, port:, encoder:, logger:, max_packet_size: = 65_000)
       @encoder = encoder
       @logger = logger
 
@@ -13,10 +13,11 @@ module Jaeger
       @protocol_class = ::Thrift::CompactProtocol
       protocol = @protocol_class.new(transport)
       @client = Jaeger::Thrift::Agent.new(protocol)
+      @max_packet_size = max_packet_size
     end
 
     def send_spans(spans)
-      batches = @encoder.encode_limited_size(spans, @protocol_class, 8_000)
+      batches = @encoder.encode_limited_size(spans, @protocol_class, @max_packet_size)
       batches.each { |batch| @client.emitBatch(batch) }
     rescue StandardError => error
       @logger.error("Failure while sending a batch of spans: #{error}")

--- a/lib/jaeger/udp_sender.rb
+++ b/lib/jaeger/udp_sender.rb
@@ -5,7 +5,7 @@ require 'socket'
 
 module Jaeger
   class UdpSender
-    def initialize(host:, port:, encoder:, logger:, max_packet_size: = 65_000)
+    def initialize(host:, port:, encoder:, logger:, max_packet_size: 65_000)
       @encoder = encoder
       @logger = logger
 

--- a/lib/jaeger/udp_sender.rb
+++ b/lib/jaeger/udp_sender.rb
@@ -12,7 +12,7 @@ module Jaeger
       transport = Transport.new(host, port)
       @protocol_class = ::Thrift::CompactProtocol
       protocol = @protocol_class.new(transport)
-      @client = Jaeger::Thrift::Agent.new(protocol)
+      @client = Jaeger::Thrift::Agent::Client.new(protocol)
       @max_packet_size = max_packet_size
     end
 


### PR DESCRIPTION
Currently, if a batch can end up being larger than the UDP message size limit, causing its transmission to fail.

This MR would add a mechanism to check the size of batches and break them up, creating a "batch of batches" so to speak.