### PR TITLE
Add b3 text map extractor

### DIFF
--- a/lib/jaeger/extractors.rb
+++ b/lib/jaeger/extractors.rb
@@ -77,7 +77,7 @@ module Jaeger
     end
 
     class B3TextMapCodec
-      class KEYS
+      class Keys
         TRACE_ID = 'x-b3-traceid'.freeze
         SPAN_ID = 'x-b3-spanid'.freeze
         PARENT_SPAN_ID = 'x-b3-parentspanid'.freeze

--- a/lib/jaeger/extractors.rb
+++ b/lib/jaeger/extractors.rb
@@ -63,39 +63,39 @@ module Jaeger
     end
 
     class B3RackCodec
-      KEYS = %w[
-        HTTP_X_B3_TRACEID
-        HTTP_X_B3_SPANID
-        HTTP_X_B3_PARENTSPANID
-        HTTP_X_B3_FLAGS
-        HTTP_X_B3_SAMPLED
-      ].freeze
+      class Keys
+        TRACE_ID = 'HTTP_X_B3_TRACEID'.freeze
+        SPAN_ID = 'HTTP_X_B3_SPANID'.freeze
+        PARENT_SPAN_ID = 'HTTP_X_B3_PARENTSPANID'.freeze
+        FLAGS = 'HTTP_X_B3_FLAGS'.freeze
+        SAMPLED = 'HTTP_X_B3_SAMPLED'.freeze
+      end.freeze
 
       def self.extract(carrier)
-        B3CodecCommon.extract(carrier, KEYS)
+        B3CodecCommon.extract(carrier, Keys)
       end
     end
 
     class B3TextMapCodec
-      KEYS = %w[
-        x-b3-traceid
-        x-b3-spanid
-        x-b3-parentspanid
-        x-b3-flags
-        x-b3-sampled
-      ].freeze
+      class KEYS
+        TRACE_ID = 'x-b3-traceid'.freeze
+        SPAN_ID = 'x-b3-spanid'.freeze
+        PARENT_SPAN_ID = 'x-b3-parentspanid'.freeze
+        FLAGS = 'x-b3-flags'.freeze
+        SAMPLED = 'x-b3-sampled'.freeze
+      end.freeze
 
       def self.extract(carrier)
-        B3CodecCommon.extract(carrier, KEYS)
+        B3CodecCommon.extract(carrier, Keys)
       end
     end
 
     class B3CodecCommon
       def self.extract(carrier, keys)
-        trace_id = TraceId.base16_hex_id_to_uint64(carrier[keys[0]])
-        span_id = TraceId.base16_hex_id_to_uint64(carrier[keys[1]])
-        parent_id = TraceId.base16_hex_id_to_uint64(carrier[keys[2]])
-        flags = parse_flags(carrier[keys[3]], carrier[keys[4]])
+        trace_id = TraceId.base16_hex_id_to_uint64(carrier[keys::TRACE_ID])
+        span_id = TraceId.base16_hex_id_to_uint64(carrier[keys::SPAN_ID])
+        parent_id = TraceId.base16_hex_id_to_uint64(carrier[keys::PARENT_SPAN_ID])
+        flags = parse_flags(carrier[keys::FLAGS], carrier[keys::SAMPLED])
 
         return nil if span_id.nil? || trace_id.nil?
         return nil if span_id.zero? || trace_id.zero?

--- a/spec/jaeger/extractors/b3_text_map_codec_spec.rb
+++ b/spec/jaeger/extractors/b3_text_map_codec_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+
+describe Jaeger::Extractors::B3TextMapCodec do
+  let(:span_context) { described_class.extract(carrier) }
+
+  let(:operation_name) { 'operator-name' }
+  let(:trace_id) { '58a515c97fd61fd7' }
+  let(:parent_id) { '8e5a8c5509c8dcc1' }
+  let(:span_id) { 'aba8be8d019abed2' }
+  let(:flags) { '1' }
+  let(:hexa_max_uint64) { 'ff' * 8 }
+  let(:max_uint64) { 2**64 - 1 }
+
+  context 'when header x-b3-sampled is present' do
+    let(:carrier) do
+      { 'x-b3-traceid'      => trace_id,
+        'x-b3-spanid'       => span_id,
+        'x-b3-parentspanid' => parent_id,
+        'x-b3-sampled'      => flags }
+    end
+
+    it 'has flags' do
+      expect(span_context.flags).to eq(flags.to_i(16))
+    end
+
+    context 'when trace-id is a max uint64' do
+      let(:trace_id) { hexa_max_uint64 }
+
+      it 'interprets it correctly' do
+        expect(span_context.trace_id).to eq(max_uint64)
+      end
+    end
+
+    context 'when parent-id is a max uint64' do
+      let(:parent_id) { hexa_max_uint64 }
+
+      it 'interprets it correctly' do
+        expect(span_context.parent_id).to eq(max_uint64)
+      end
+    end
+
+    context 'when span-id is a max uint64' do
+      let(:span_id) { hexa_max_uint64 }
+
+      it 'interprets it correctly' do
+        expect(span_context.span_id).to eq(max_uint64)
+      end
+    end
+
+    context 'when parent-id is 0' do
+      let(:parent_id) { '0' }
+
+      it 'sets parent_id to 0' do
+        expect(span_context.parent_id).to eq(0)
+      end
+    end
+
+    context 'when trace-id is missing' do
+      let(:trace_id) { nil }
+
+      it 'returns nil' do
+        expect(span_context).to eq(nil)
+      end
+    end
+
+    context 'when span-id is missing' do
+      let(:span_id) { nil }
+
+      it 'returns nil' do
+        expect(span_context).to eq(nil)
+      end
+    end
+  end
+
+  context 'when header x-b3-flags is present' do
+    let(:carrier) do
+      { 'x-b3-traceid'      => trace_id,
+        'x-b3-spanid'       => span_id,
+        'x-b3-parentspanid' => parent_id,
+        'x-b3-flags'        => '1' }
+    end
+
+    it 'sets the DEBUG flag' do
+      expect(span_context.flags).to eq(0x02)
+    end
+  end
+end


### PR DESCRIPTION
There was no extractor for B3TextMapCodec when requests do not come in through Rack. The particular case I ran into was with AWS Lambdas in Ruby, which may be a pretty common use case.

Please let me know what you think