### PR TITLE
Improve thrift encoder 's encode_limited_size

### DIFF
--- a/jaeger-client.gemspec
+++ b/jaeger-client.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.54.0'

--- a/spec/jaeger/encoders/thrift_encoder_spec.rb
+++ b/spec/jaeger/encoders/thrift_encoder_spec.rb
@@ -95,7 +95,6 @@ RSpec.describe Jaeger::Encoders::ThriftEncoder do
       encoded_batches = encoder.encode_limited_size(example_spans, ::Thrift::CompactProtocol, 5_000)
       expect(encoded_batches.length).to be(2)
       expect(encoded_batches.first.spans.first).to be_a_valid_thrift_span
-      expect(encoded_batches.first.spans.first).to be_a_valid_thrift_span
       expect(encoded_batches.first.spans.last).to be_a_valid_thrift_span
       expect(encoded_batches.last.spans.first).to be_a_valid_thrift_span
       expect(encoded_batches.last.spans.last).to be_a_valid_thrift_span

--- a/spec/jaeger/encoders/thrift_encoder_spec.rb
+++ b/spec/jaeger/encoders/thrift_encoder_spec.rb
@@ -1,5 +1,20 @@
 require 'spec_helper'
 
+RSpec::Matchers.define :be_a_valid_span do |_|
+  match do |actual|
+    actual.instance_of?(::Jaeger::Thrift::Span) &&
+      !actual.instance_variable_get(:@traceIdLow).nil? &&
+      !actual.instance_variable_get(:@traceIdHigh).nil? &&
+      !actual.instance_variable_get(:@spanId).nil? &&
+      !actual.instance_variable_get(:@parentSpanId).nil? &&
+      !actual.instance_variable_get(:@operationName).nil? &&
+      !actual.instance_variable_get(:@flags).nil? &&
+      !actual.instance_variable_get(:@startTime).nil? &&
+      !actual.instance_variable_get(:@duration).nil? &&
+      !actual.instance_variable_get(:@tags).nil?
+  end
+end
+
 RSpec.describe Jaeger::Encoders::ThriftEncoder do
   let(:encoder) { described_class.new(service_name: service_name, tags: tags) }
   let(:service_name) { 'service-name' }
@@ -44,6 +59,47 @@ RSpec.describe Jaeger::Encoders::ThriftEncoder do
       tags = encoder.encode([]).process.tags
       ip_tag = tags.detect { |tag| tag.key == 'ip' }
       expect(ip_tag.vStr).to eq(ip)
+    end
+  end
+
+  context 'when spans are encoded without limit' do
+    let(:context) do
+      Jaeger::SpanContext.new(
+        trace_id: Jaeger::TraceId.generate,
+        span_id: Jaeger::TraceId.generate,
+        flags: Jaeger::SpanContext::Flags::DEBUG
+      )
+    end
+    let(:example_span) { Jaeger::Span.new(context, 'example_op', nil) }
+
+    it 'encode successfully' do
+      encoded_span = encoder.encode([example_span])
+      expect(encoded_span.spans.first).to be_a_valid_span
+    end
+  end
+
+  context 'when spans are encoded with limits' do
+    let(:context) do
+      Jaeger::SpanContext.new(
+        trace_id: Jaeger::TraceId.generate,
+        span_id: Jaeger::TraceId.generate,
+        flags: Jaeger::SpanContext::Flags::DEBUG
+      )
+    end
+    let(:example_span) { Jaeger::Span.new(context, 'example_op', nil) }
+    # example span have size of 63, so let's make an array of 100 span
+    # and set the limit at 5000, so it should return a batch of 2
+    let(:example_spans) { Array.new(100, example_span) }
+
+    it 'encode successfully in batches' do
+      encoded_span_batches = encoder.encode_limited_size(example_spans, ::Thrift::CompactProtocol, 5_000)
+
+      expect(encoded_span_batches.length).to be(2)
+      expect(encoded_span_batches.first.spans.first).to be_a_valid_span
+      expect(encoded_span_batches.first.spans.first).to be_a_valid_span
+      expect(encoded_span_batches.first.spans.last).to be_a_valid_span
+      expect(encoded_span_batches.last.spans.first).to be_a_valid_span
+      expect(encoded_span_batches.last.spans.last).to be_a_valid_span
     end
   end
 end


### PR DESCRIPTION
This improve https://github.com/salemove/jaeger-client-ruby/pull/22. I was originally planned to continue that PR but later found that it is merged into master via another commit. 