### PR TITLE
Ensure buffer is never larger than a UDP packet

### DIFF
--- a/lib/jaeger/udp_sender/transport.rb
+++ b/lib/jaeger/udp_sender/transport.rb
@@ -4,6 +4,7 @@ module Jaeger
   class UdpSender
     class Transport
       FLAGS = 0
+      MAX_PACKET_SIZE = 65_507
 
       def initialize(host, port)
         @socket = UDPSocket.new
@@ -13,6 +14,8 @@ module Jaeger
       end
 
       def write(str)
+        buffer_size = str.bytesize + @buffer.available
+        flush if buffer_size > MAX_PACKET_SIZE
         @buffer.write(str)
       end
 


### PR DESCRIPTION
Flush the buffer if writing would make the buffer larger than the maximum UDP packet size