### PR TITLE
Make it more explicit that the reporter sends data in background

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ OpenTracing.start_active_span('span name') do
     # do something else
   end
 end
+
+# don't kill the program too soon, allow time for the background reporter to send the traces
+sleep 2
 ```
 
 See [opentracing-ruby](https://github.com/opentracing/opentracing-ruby) for more examples.


### PR DESCRIPTION
Minor update to the README to make it more explicit that sending traces
happens in the background. I just spent significant time trying to
debug my stack because I tried running the README example and it wasn't
showing up in Jaeger.