### PR TITLE
Ruby 3 upgrades

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,11 @@
 require: rubocop-rspec
 
+
 AllCops:
+  TargetRubyVersion: 2.7.2
   Exclude:
     - 'thrift/**/*'
+  NewCops: enable
 
 Style/Documentation:
   Enabled: no
@@ -16,10 +19,13 @@ RSpec/NestedGroups:
 RSpec/ExampleLength:
   Enabled: no
 
+RSpec/MessageSpies:
+  Enabled: no
+
 RSpec/MultipleExpectations:
   Enabled: no
 
-RSpec/MessageSpies:
+RSpec/MultipleMemoizedHelpers:
   Enabled: no
 
 Metrics/BlockLength:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 
 rvm:
   - 2.7.2
+  - 3.0.1
 
 services:
   - docker

--- a/crossdock/Dockerfile
+++ b/crossdock/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5-alpine
+FROM ruby:3.0-alpine
 
 ENV APP_HOME /app
 

--- a/crossdock/Dockerfile
+++ b/crossdock/Dockerfile
@@ -5,12 +5,15 @@ ENV APP_HOME /app
 # git is required by bundler to run jaeger gem with local path
 RUN apk add --no-cache git
 
+
 # Add only files needed for installing gem dependencies. This allows us to
 # change other files without needing to install gems every time when building
 # the docker image.
 ADD Gemfile Gemfile.lock jaeger-client.gemspec $APP_HOME/
 ADD lib/jaeger/client/version.rb $APP_HOME/lib/jaeger/client/
 ADD crossdock/Gemfile crossdock/Gemfile.lock $APP_HOME/crossdock/
+
+RUN gem install bundler -v $(tail -n 1 $APP_HOME/Gemfile.lock | awk '{$1=$1};1')
 
 RUN apk add --no-cache --virtual .app-builddeps build-base \
   && cd $APP_HOME && bundle install \

--- a/crossdock/Gemfile.lock
+++ b/crossdock/Gemfile.lock
@@ -34,4 +34,4 @@ DEPENDENCIES
   webrick (~> 1.4.2)
 
 BUNDLED WITH
-   1.17.3
+   2.2.15

--- a/crossdock/server
+++ b/crossdock/server
@@ -36,9 +36,10 @@ class HttpServer < Sinatra::Application
       transport = downstream['transport']
 
       response[:downstream] =
-        if transport == 'HTTP'
+        case transport
+        when 'HTTP'
           call_downstream_http(downstream, server_span)
-        elsif transport == 'DUMMY'
+        when 'DUMMY'
           { notImplementedError: 'Dummy has not been implemented' }
         else
           { notImplementedError: "Unrecognized transport received: #{transport}" }
@@ -69,9 +70,10 @@ class HttpServer < Sinatra::Application
       transport = downstream['transport']
 
       response[:downstream] =
-        if transport == 'HTTP'
+        case transport
+        when 'HTTP'
           call_downstream_http(downstream, server_span)
-        elsif transport == 'DUMMY'
+        when 'DUMMY'
           { notImplementedError: 'Dummy has not been implemented' }
         else
           { notImplementedError: "Unrecognized transport received: #{transport}" }

--- a/jaeger-client.gemspec
+++ b/jaeger-client.gemspec
@@ -19,14 +19,15 @@ Gem::Specification.new do |spec|
   end
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '~> 0.54.0'
-  spec.add_development_dependency 'rubocop-rspec', '~> 1.24.0'
+  spec.add_development_dependency 'rubocop', '~> 0.54'
+  spec.add_development_dependency 'rubocop-rspec', '~> 1.24'
   spec.add_development_dependency 'timecop', '~> 0.9'
-  spec.add_development_dependency 'webmock', '~> 3.4.2'
+  spec.add_development_dependency 'webmock', '~> 3.4'
 
   spec.add_dependency 'opentracing', '~> 0.3'
   spec.add_dependency 'thrift'

--- a/jaeger-client.gemspec
+++ b/jaeger-client.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   end
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 3.0'
+  spec.required_ruby_version = '>= 2.7'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/lib/jaeger/client.rb
+++ b/lib/jaeger/client.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.push(File.dirname(__FILE__) + '/../../thrift/gen-rb')
+$LOAD_PATH.push("#{File.dirname(__FILE__)}/../../thrift/gen-rb")
 
 require 'opentracing'
 require 'jaeger/thrift/agent'
@@ -43,12 +43,11 @@ module Jaeger
 
     DEFAULT_FLUSH_INTERVAL = 10
 
-    def self.build(host: '127.0.0.1',
+    def self.build(service_name:, host: '127.0.0.1',
                    port: 6831,
-                   service_name:,
                    flush_interval: DEFAULT_FLUSH_INTERVAL,
                    sampler: Samplers::Const.new(true),
-                   logger: Logger.new(STDOUT),
+                   logger: Logger.new($stdout),
                    sender: nil,
                    reporter: nil,
                    injectors: {},

--- a/lib/jaeger/client/version.rb
+++ b/lib/jaeger/client/version.rb
@@ -2,6 +2,6 @@
 
 module Jaeger
   module Client
-    VERSION = '1.1.0'.freeze
+    VERSION = '1.1.0'
   end
 end

--- a/lib/jaeger/encoders/thrift_encoder.rb
+++ b/lib/jaeger/encoders/thrift_encoder.rb
@@ -87,7 +87,7 @@ module Jaeger
 
       def prepare_tags(tags)
         with_default_tags = tags.dup
-        with_default_tags['jaeger.version'] = 'Ruby-' + Jaeger::Client::VERSION
+        with_default_tags['jaeger.version'] = "Ruby-#{Jaeger::Client::VERSION}"
         with_default_tags['hostname'] ||= Socket.gethostname
 
         unless with_default_tags['ip']

--- a/lib/jaeger/extractors.rb
+++ b/lib/jaeger/extractors.rb
@@ -66,11 +66,11 @@ module Jaeger
 
     class B3RackCodec
       class Keys
-        TRACE_ID = 'HTTP_X_B3_TRACEID'.freeze
-        SPAN_ID = 'HTTP_X_B3_SPANID'.freeze
-        PARENT_SPAN_ID = 'HTTP_X_B3_PARENTSPANID'.freeze
-        FLAGS = 'HTTP_X_B3_FLAGS'.freeze
-        SAMPLED = 'HTTP_X_B3_SAMPLED'.freeze
+        TRACE_ID = 'HTTP_X_B3_TRACEID'
+        SPAN_ID = 'HTTP_X_B3_SPANID'
+        PARENT_SPAN_ID = 'HTTP_X_B3_PARENTSPANID'
+        FLAGS = 'HTTP_X_B3_FLAGS'
+        SAMPLED = 'HTTP_X_B3_SAMPLED'
       end.freeze
 
       def self.extract(carrier)
@@ -80,11 +80,11 @@ module Jaeger
 
     class B3TextMapCodec
       class Keys
-        TRACE_ID = 'x-b3-traceid'.freeze
-        SPAN_ID = 'x-b3-spanid'.freeze
-        PARENT_SPAN_ID = 'x-b3-parentspanid'.freeze
-        FLAGS = 'x-b3-flags'.freeze
-        SAMPLED = 'x-b3-sampled'.freeze
+        TRACE_ID = 'x-b3-traceid'
+        SPAN_ID = 'x-b3-spanid'
+        PARENT_SPAN_ID = 'x-b3-parentspanid'
+        FLAGS = 'x-b3-flags'
+        SAMPLED = 'x-b3-sampled'
       end.freeze
 
       def self.extract(carrier)
@@ -129,10 +129,10 @@ module Jaeger
 
     class TraceContextRackCodec
       # Internal regex used to identify the TraceContext version
-      VERSION_PATTERN = /^([0-9a-fA-F]{2})-(.+)$/
+      VERSION_PATTERN = /^([0-9a-fA-F]{2})-(.+)$/.freeze
 
       # Internal regex used to parse fields in version 0
-      HEADER_V0_PATTERN = /^([0-9a-fA-F]{32})-([0-9a-fA-F]{16})(-([0-9a-fA-F]{2}))?$/
+      HEADER_V0_PATTERN = /^([0-9a-fA-F]{32})-([0-9a-fA-F]{16})(-([0-9a-fA-F]{2}))?$/.freeze
 
       def self.extract(carrier)
         header_value = carrier['HTTP_TRACEPARENT']

--- a/lib/jaeger/http_sender.rb
+++ b/lib/jaeger/http_sender.rb
@@ -4,7 +4,7 @@ require 'logger'
 
 module Jaeger
   class HttpSender
-    def initialize(url:, headers: {}, encoder:, logger: Logger.new(STDOUT))
+    def initialize(url:, encoder:, headers: {}, logger: Logger.new($stdout))
       @encoder = encoder
       @logger = logger
 
@@ -21,8 +21,8 @@ module Jaeger
       batch = @encoder.encode(spans)
       @transport.write(@serializer.serialize(batch))
       @transport.flush
-    rescue StandardError => error
-      @logger.error("Failure while sending a batch of spans: #{error}")
+    rescue StandardError => e
+      @logger.error("Failure while sending a batch of spans: #{e}")
     end
   end
 end

--- a/lib/jaeger/recurring_executor.rb
+++ b/lib/jaeger/recurring_executor.rb
@@ -24,7 +24,7 @@ module Jaeger
     end
 
     def running?
-      @thread && @thread.alive?
+      @thread&.alive?
     end
 
     def stop

--- a/lib/jaeger/samplers/guaranteed_throughput_probabilistic.rb
+++ b/lib/jaeger/samplers/guaranteed_throughput_probabilistic.rb
@@ -30,16 +30,16 @@ module Jaeger
         is_updated
       end
 
-      def sample(*args)
-        is_sampled, probabilistic_tags = @probabilistic_sampler.sample(*args)
+      def sample(**args)
+        is_sampled, probabilistic_tags = @probabilistic_sampler.sample(**args)
         if is_sampled
           # We still call lower_bound_sampler to update the rate limiter budget
-          @lower_bound_sampler.sample(*args)
+          @lower_bound_sampler.sample(**args)
 
           return [is_sampled, probabilistic_tags]
         end
 
-        is_sampled, _tags = @lower_bound_sampler.sample(*args)
+        is_sampled, _tags = @lower_bound_sampler.sample(**args)
         [is_sampled, @lower_bound_tags]
       end
     end

--- a/lib/jaeger/samplers/per_operation.rb
+++ b/lib/jaeger/samplers/per_operation.rb
@@ -32,9 +32,7 @@ module Jaeger
           @default_sampler = Probabilistic.new(rate: @default_sampling_probability)
         end
 
-        is_updated = update_operation_strategies(strategies) || is_updated
-
-        is_updated
+        update_operation_strategies(strategies) || is_updated
       end
 
       def sample(opts)

--- a/lib/jaeger/samplers/per_operation.rb
+++ b/lib/jaeger/samplers/per_operation.rb
@@ -40,16 +40,16 @@ module Jaeger
       def sample(opts)
         operation_name = opts.fetch(:operation_name)
         sampler = @samplers[operation_name]
-        return sampler.sample(opts) if sampler
+        return sampler.sample(**opts) if sampler
 
-        return @default_sampler.sample(opts) if @samplers.length >= @max_operations
+        return @default_sampler.sample(**opts) if @samplers.length >= @max_operations
 
         sampler = GuaranteedThroughputProbabilistic.new(
           lower_bound: @lower_bound,
           rate: @default_sampling_probability
         )
         @samplers[operation_name] = sampler
-        sampler.sample(opts)
+        sampler.sample(**opts)
       end
 
       private

--- a/lib/jaeger/samplers/remote_controlled.rb
+++ b/lib/jaeger/samplers/remote_controlled.rb
@@ -6,7 +6,7 @@ module Jaeger
   module Samplers
     class RemoteControlled
       DEFAULT_REFRESH_INTERVAL = 60
-      DEFAULT_SAMPLING_HOST = 'localhost'.freeze
+      DEFAULT_SAMPLING_HOST = 'localhost'
       DEFAULT_SAMPLING_PORT = 5778
 
       attr_reader :sampler

--- a/lib/jaeger/samplers/remote_controlled.rb
+++ b/lib/jaeger/samplers/remote_controlled.rb
@@ -28,10 +28,10 @@ module Jaeger
         end
       end
 
-      def sample(*args)
+      def sample(**args)
         @poll_executor.start(&method(:poll)) unless @poll_executor.running?
 
-        @sampler.sample(*args)
+        @sampler.sample(**args)
       end
 
       def poll

--- a/lib/jaeger/scope.rb
+++ b/lib/jaeger/scope.rb
@@ -23,6 +23,7 @@ module Jaeger
     # updating the ScopeManager#active in the process.
     def close
       raise "Tried to close already closed span: #{inspect}" if @closed
+
       @closed = true
 
       @span.finish if @finish_on_close

--- a/lib/jaeger/scope_manager.rb
+++ b/lib/jaeger/scope_manager.rb
@@ -27,6 +27,7 @@ module Jaeger
     #  returned instance.
     def activate(span, finish_on_close: true)
       return active if active && active.span == span
+
       scope = Scope.new(span, @scope_stack, finish_on_close: finish_on_close)
       @scope_stack.push(scope)
       scope

--- a/lib/jaeger/span.rb
+++ b/lib/jaeger/span.rb
@@ -34,7 +34,7 @@ module Jaeger
     # a String, Numeric, or Boolean it will be encoded with to_s
     def set_tag(key, value)
       if key == 'sampling.priority'
-        if value.to_i > 0
+        if value.to_i.positive?
           return self if @context.debug?
 
           @context.flags = @context.flags | SpanContext::Flags::SAMPLED | SpanContext::Flags::DEBUG

--- a/lib/jaeger/span.rb
+++ b/lib/jaeger/span.rb
@@ -71,9 +71,9 @@ module Jaeger
     # Add a log entry to this span
     #
     # @deprecated Use {#log_kv} instead.
-    def log(*args)
+    def log(**args)
       warn 'Span#log is deprecated. Please use Span#log_kv instead.'
-      log_kv(*args)
+      log_kv(**args)
     end
 
     # Add a log entry to this span

--- a/lib/jaeger/span_context.rb
+++ b/lib/jaeger/span_context.rb
@@ -19,10 +19,10 @@ module Jaeger
       )
     end
 
-    attr_reader :span_id, :parent_id, :trace_id, :baggage, :flags
-    attr_writer :flags
+    attr_accessor :flags
+    attr_reader :span_id, :parent_id, :trace_id, :baggage
 
-    def initialize(span_id:, parent_id: 0, trace_id:, flags:, baggage: {})
+    def initialize(span_id:, trace_id:, flags:, parent_id: 0, baggage: {})
       @span_id = span_id
       @parent_id = parent_id
       @trace_id = trace_id

--- a/lib/jaeger/thrift_tag_builder.rb
+++ b/lib/jaeger/thrift_tag_builder.rb
@@ -11,19 +11,20 @@ module Jaeger
     VSTR = FIELDS[Jaeger::Thrift::Tag::VSTR].fetch(:name)
 
     def self.build(key, value)
-      if value.is_a?(Integer)
+      case value
+      when Integer
         Jaeger::Thrift::Tag.new(
           KEY => key.to_s,
           VTYPE => Jaeger::Thrift::TagType::LONG,
           VLONG => value
         )
-      elsif value.is_a?(Float)
+      when Float
         Jaeger::Thrift::Tag.new(
           KEY => key.to_s,
           VTYPE => Jaeger::Thrift::TagType::DOUBLE,
           VDOUBLE => value
         )
-      elsif value.is_a?(TrueClass) || value.is_a?(FalseClass)
+      when TrueClass, FalseClass
         Jaeger::Thrift::Tag.new(
           KEY => key.to_s,
           VTYPE => Jaeger::Thrift::TagType::BOOL,

--- a/lib/jaeger/trace_id.rb
+++ b/lib/jaeger/trace_id.rb
@@ -15,14 +15,14 @@ module Jaeger
       return nil unless id
 
       value = id.to_i(16)
-      value > MAX_64BIT_UNSIGNED_INT || value < 0 ? 0 : value
+      value > MAX_64BIT_UNSIGNED_INT || value.negative? ? 0 : value
     end
 
     def self.base16_hex_id_to_uint128(id)
       return nil unless id
 
       value = id.to_i(16)
-      value > MAX_128BIT_UNSIGNED_INT || value < 0 ? 0 : value
+      value > MAX_128BIT_UNSIGNED_INT || value.negative? ? 0 : value
     end
 
     # Thrift defines ID fields as i64, which is signed, therefore we convert

--- a/lib/jaeger/tracer.rb
+++ b/lib/jaeger/tracer.rb
@@ -19,7 +19,7 @@ module Jaeger
     #   Scope#active is nil.
     def active_span
       scope = scope_manager.active
-      scope.span if scope
+      scope&.span
     end
 
     # Starts a new span.
@@ -190,6 +190,7 @@ module Jaeger
 
     def context_from_child_of(child_of)
       return nil unless child_of
+
       child_of.respond_to?(:context) ? child_of.context : child_of
     end
 
@@ -207,7 +208,7 @@ module Jaeger
       return if ignore_active_scope
 
       active_scope = @scope_manager.active
-      active_scope.span.context if active_scope
+      active_scope&.span&.context
     end
   end
 end

--- a/lib/jaeger/udp_sender.rb
+++ b/lib/jaeger/udp_sender.rb
@@ -19,8 +19,8 @@ module Jaeger
     def send_spans(spans)
       batches = @encoder.encode_limited_size(spans, @protocol_class, @max_packet_size)
       batches.each { |batch| @client.emitBatch(batch) }
-    rescue StandardError => error
-      @logger.error("Failure while sending a batch of spans: #{error}")
+    rescue StandardError => e
+      @logger.error("Failure while sending a batch of spans: #{e}")
     end
   end
 end

--- a/spec/jaeger/extractors/b3_rack_codec_spec.rb
+++ b/spec/jaeger/extractors/b3_rack_codec_spec.rb
@@ -15,10 +15,10 @@ describe Jaeger::Extractors::B3RackCodec do
 
   context 'when header HTTP_X_B3_SAMPLED is present' do
     let(:carrier) do
-      { 'HTTP_X_B3_TRACEID'      => trace_id,
-        'HTTP_X_B3_SPANID'       => span_id,
+      { 'HTTP_X_B3_TRACEID' => trace_id,
+        'HTTP_X_B3_SPANID' => span_id,
         'HTTP_X_B3_PARENTSPANID' => parent_id,
-        'HTTP_X_B3_SAMPLED'      => flags }
+        'HTTP_X_B3_SAMPLED' => flags }
     end
 
     it 'has flags' do
@@ -84,10 +84,10 @@ describe Jaeger::Extractors::B3RackCodec do
 
   context 'when header HTTP_X_B3_FLAGS is present' do
     let(:carrier) do
-      { 'HTTP_X_B3_TRACEID'      => trace_id,
-        'HTTP_X_B3_SPANID'       => span_id,
+      { 'HTTP_X_B3_TRACEID' => trace_id,
+        'HTTP_X_B3_SPANID' => span_id,
         'HTTP_X_B3_PARENTSPANID' => parent_id,
-        'HTTP_X_B3_FLAGS'        => '1' }
+        'HTTP_X_B3_FLAGS' => '1' }
     end
 
     it 'sets the DEBUG flag' do

--- a/spec/jaeger/extractors/b3_text_map_codec_spec.rb
+++ b/spec/jaeger/extractors/b3_text_map_codec_spec.rb
@@ -15,10 +15,10 @@ describe Jaeger::Extractors::B3TextMapCodec do
 
   context 'when header x-b3-sampled is present' do
     let(:carrier) do
-      { 'x-b3-traceid'      => trace_id,
-        'x-b3-spanid'       => span_id,
+      { 'x-b3-traceid' => trace_id,
+        'x-b3-spanid' => span_id,
         'x-b3-parentspanid' => parent_id,
-        'x-b3-sampled'      => flags }
+        'x-b3-sampled' => flags }
     end
 
     it 'has flags' do
@@ -84,10 +84,10 @@ describe Jaeger::Extractors::B3TextMapCodec do
 
   context 'when header x-b3-flags is present' do
     let(:carrier) do
-      { 'x-b3-traceid'      => trace_id,
-        'x-b3-spanid'       => span_id,
+      { 'x-b3-traceid' => trace_id,
+        'x-b3-spanid' => span_id,
         'x-b3-parentspanid' => parent_id,
-        'x-b3-flags'        => '1' }
+        'x-b3-flags' => '1' }
     end
 
     it 'sets the DEBUG flag' do

--- a/spec/jaeger/rate_limiter_spec.rb
+++ b/spec/jaeger/rate_limiter_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Jaeger::RateLimiter do
   end
 
   def build_limiter(credits_per_second:, **opts)
-    described_class.new({
+    described_class.new(**{
       credits_per_second: credits_per_second,
       max_balance: credits_per_second
     }.merge(opts))

--- a/spec/jaeger/samplers/const_spec.rb
+++ b/spec/jaeger/samplers/const_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe Jaeger::Samplers::Const do
   let(:sampler) { described_class.new(decision) }
   let(:sample_args) { { trace_id: Jaeger::TraceId.generate } }
-  let(:sample_result) { sampler.sample(sample_args) }
+  let(:sample_result) { sampler.sample(**sample_args) }
   let(:is_sampled) { sample_result[0] }
   let(:tags) { sample_result[1] }
 

--- a/spec/jaeger/samplers/guaranteed_throughput_probabilistic_spec.rb
+++ b/spec/jaeger/samplers/guaranteed_throughput_probabilistic_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Jaeger::Samplers::GuaranteedThroughputProbabilistic do
 
   let(:max_traces_per_second) { 10 }
   let(:sample_args) { { trace_id: trace_id } }
-  let(:sample_result) { sampler.sample(sample_args) }
+  let(:sample_result) { sampler.sample(**sample_args) }
   let(:is_sampled) { sample_result[0] }
   let(:tags) { sample_result[1] }
 

--- a/spec/jaeger/samplers/per_operation_spec.rb
+++ b/spec/jaeger/samplers/per_operation_spec.rb
@@ -22,20 +22,20 @@ RSpec.describe Jaeger::Samplers::PerOperation do
       end
 
       it 'uses lower bound sampler' do
-        is_sampled, _tags = sampler.sample(sample_args(operation_name: 'foo'))
+        is_sampled, _tags = sampler.sample(**sample_args(operation_name: 'foo'))
         expect(is_sampled).to eq(true)
 
         # false because limit is full
-        is_sampled, _tags = sampler.sample(sample_args(operation_name: 'foo'))
+        is_sampled, _tags = sampler.sample(**sample_args(operation_name: 'foo'))
         expect(is_sampled).to eq(false)
 
         # true because different operation
-        is_sampled, _tags = sampler.sample(sample_args(operation_name: 'bar'))
+        is_sampled, _tags = sampler.sample(**sample_args(operation_name: 'bar'))
         expect(is_sampled).to eq(true)
       end
 
       it 'returns tags with lower bound param' do
-        _is_sampled, tags = sampler.sample(sample_args(operation_name: 'foo'))
+        _is_sampled, tags = sampler.sample(**sample_args(operation_name: 'foo'))
         expect(tags).to eq(
           'sampler.type' => 'lowerbound',
           'sampler.param' => 0
@@ -55,23 +55,23 @@ RSpec.describe Jaeger::Samplers::PerOperation do
       end
 
       it 'uses operation probabilistic sampler' do
-        is_sampled, _tags = sampler.sample(sample_args(operation_name: 'foo'))
+        is_sampled, _tags = sampler.sample(**sample_args(operation_name: 'foo'))
         expect(is_sampled).to eq(true)
 
         # true because rate is set to 1
-        is_sampled, _tags = sampler.sample(sample_args(operation_name: 'foo'))
+        is_sampled, _tags = sampler.sample(**sample_args(operation_name: 'foo'))
         expect(is_sampled).to eq(true)
 
-        is_sampled, _tags = sampler.sample(sample_args(operation_name: 'bar'))
+        is_sampled, _tags = sampler.sample(**sample_args(operation_name: 'bar'))
         expect(is_sampled).to eq(true)
 
         # false because different operation and lower boundary is full
-        is_sampled, _tags = sampler.sample(sample_args(operation_name: 'bar'))
+        is_sampled, _tags = sampler.sample(**sample_args(operation_name: 'bar'))
         expect(is_sampled).to eq(false)
       end
 
       it 'returns tags with lower bound param' do
-        _is_sampled, tags = sampler.sample(sample_args(operation_name: 'foo'))
+        _is_sampled, tags = sampler.sample(**sample_args(operation_name: 'foo'))
         expect(tags).to eq(
           'sampler.type' => 'probabilistic',
           'sampler.param' => 1.0
@@ -90,20 +90,20 @@ RSpec.describe Jaeger::Samplers::PerOperation do
       end
 
       it 'uses lower bound sampler' do
-        is_sampled, _tags = sampler.sample(sample_args(operation_name: 'foo'))
+        is_sampled, _tags = sampler.sample(**sample_args(operation_name: 'foo'))
         expect(is_sampled).to eq(true)
 
         # false because limit is full
-        is_sampled, _tags = sampler.sample(sample_args(operation_name: 'foo'))
+        is_sampled, _tags = sampler.sample(**sample_args(operation_name: 'foo'))
         expect(is_sampled).to eq(false)
 
         # true because different operation
-        is_sampled, _tags = sampler.sample(sample_args(operation_name: 'bar'))
+        is_sampled, _tags = sampler.sample(**sample_args(operation_name: 'bar'))
         expect(is_sampled).to eq(true)
       end
 
       it 'returns tags with lower bound param' do
-        _is_sampled, tags = sampler.sample(sample_args(operation_name: 'foo'))
+        _is_sampled, tags = sampler.sample(**sample_args(operation_name: 'foo'))
         expect(tags).to eq(
           'sampler.type' => 'lowerbound',
           'sampler.param' => 0
@@ -120,15 +120,15 @@ RSpec.describe Jaeger::Samplers::PerOperation do
       end
 
       it 'uses probabilistic sampling which returns always true' do
-        is_sampled, _tags = sampler.sample(sample_args(operation_name: 'foo'))
+        is_sampled, _tags = sampler.sample(**sample_args(operation_name: 'foo'))
         expect(is_sampled).to eq(true)
 
-        is_sampled, _tags = sampler.sample(sample_args(operation_name: 'foo'))
+        is_sampled, _tags = sampler.sample(**sample_args(operation_name: 'foo'))
         expect(is_sampled).to eq(true)
       end
 
       it 'returns tags with lower bound param' do
-        _is_sampled, tags = sampler.sample(sample_args(operation_name: 'foo'))
+        _is_sampled, tags = sampler.sample(**sample_args(operation_name: 'foo'))
         expect(tags).to eq(
           'sampler.type' => 'probabilistic',
           'sampler.param' => 1

--- a/spec/jaeger/samplers/probabilistic_spec.rb
+++ b/spec/jaeger/samplers/probabilistic_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe Jaeger::Samplers::Probabilistic do
   let(:sampler) { described_class.new(rate: rate) }
   let(:sample_args) { { trace_id: trace_id } }
-  let(:sample_result) { sampler.sample(sample_args) }
+  let(:sample_result) { sampler.sample(**sample_args) }
   let(:is_sampled) { sample_result[0] }
   let(:tags) { sample_result[1] }
 

--- a/spec/jaeger/samplers/rate_limiting_spec.rb
+++ b/spec/jaeger/samplers/rate_limiting_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Jaeger::Samplers::RateLimiting do
   let(:sampler) { described_class.new(max_traces_per_second: max_traces_per_second) }
   let(:max_traces_per_second) { 10 }
   let(:sample_args) { { trace_id: Jaeger::TraceId.generate } }
-  let(:sample_result) { sampler.sample(sample_args) }
+  let(:sample_result) { sampler.sample(**sample_args) }
   let(:is_sampled) { sample_result[0] }
   let(:tags) { sample_result[1] }
 

--- a/spec/jaeger/span_context_spec.rb
+++ b/spec/jaeger/span_context_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Jaeger::SpanContext do
   end
 
   def build_span_context(opts)
-    described_class.new({
+    described_class.new(**{
       trace_id: Jaeger::TraceId.generate,
       span_id: Jaeger::TraceId.generate,
       flags: 0

--- a/spec/jaeger/span_spec.rb
+++ b/spec/jaeger/span_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Jaeger::Span do
     end
 
     it 'adds log to span' do
-      span.log_kv(fields)
+      span.log_kv(**fields)
 
       expect(span.logs.count).to eq(1)
       thrift_log = span.logs[0]
@@ -26,7 +26,7 @@ RSpec.describe Jaeger::Span do
 
     it 'adds log to span with specific timestamp' do
       timestamp = Time.now
-      span.log_kv(fields.merge(timestamp: timestamp))
+      span.log_kv(**fields.merge(timestamp: timestamp))
 
       expect(span.logs.count).to eq(1)
       thrift_log = span.logs[0]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,7 @@ RSpec.configure do |config|
   end
 
   def build_span_context(opts = {})
-    Jaeger::SpanContext.new({
+    Jaeger::SpanContext.new(**{
       trace_id: Jaeger::TraceId.generate,
       span_id: Jaeger::TraceId.generate,
       flags: Jaeger::SpanContext::Flags::SAMPLED
@@ -25,6 +25,6 @@ RSpec.configure do |config|
     operation_name = opts.delete(:operation_name) || 'operation-name'
     reporter = opts.delete(:reporter) || Jaeger::Reporters::NullReporter.new
 
-    Jaeger::Span.new(span_context, operation_name, reporter, opts)
+    Jaeger::Span.new(span_context, operation_name, reporter, **opts)
   end
 end


### PR DESCRIPTION
The Jaeger ruby client required a bunch of changes to make ruby 3 compatible besides the small kwargs shim that we initially attempted.

Updated RSpec and Rubocop along with the required Ruby 3 upgrades