### PR TITLE
Fix encode trace_id halfs of references

### DIFF
--- a/lib/jaeger/encoders/thrift_encoder.rb
+++ b/lib/jaeger/encoders/thrift_encoder.rb
@@ -59,8 +59,8 @@ module Jaeger
         references.map do |ref|
           Jaeger::Thrift::SpanRef.new(
             'refType' => span_ref_type(ref.type),
-            'traceIdLow' => TraceId.uint64_id_to_int64(ref.context.trace_id),
-            'traceIdHigh' => 0,
+            'traceIdLow' => TraceId.uint64_id_to_int64(trace_id_to_low(ref.context.trace_id)),
+            'traceIdHigh' => TraceId.uint64_id_to_int64(trace_id_to_high(ref.context.trace_id)),
             'spanId' => TraceId.uint64_id_to_int64(ref.context.span_id)
           )
         end


### PR DESCRIPTION
Hi!

This PR fixes the following error:
```
Failure while sending a batch of spans: bignum too big to convert into `long long'
```

Such errors occur when we try to associate spans with traces created in OpenTelemetry (golang). OTEL creates 128-bit trace_ids.