### PR TITLE
Fix packet size calculation of thrift batch

### DIFF
--- a/lib/jaeger/client.rb
+++ b/lib/jaeger/client.rb
@@ -54,7 +54,7 @@ module Jaeger
                    injectors: {},
                    extractors: {},
                    tags: {})
-      encoder = Encoders::ThriftEncoder.new(service_name: service_name, tags: tags)
+      encoder = Encoders::ThriftEncoder.new(service_name: service_name, tags: tags, logger: logger)
 
       if sender
         warn '[DEPRECATION] Passing `sender` directly to Jaeger::Client.build is deprecated.' \

--- a/lib/jaeger/udp_sender.rb
+++ b/lib/jaeger/udp_sender.rb
@@ -9,7 +9,7 @@ module Jaeger
       @encoder = encoder
       @logger = logger
 
-      transport = Transport.new(host, port)
+      transport = Transport.new(host, port, logger: logger)
       @protocol_class = ::Thrift::CompactProtocol
       protocol = @protocol_class.new(transport)
       @client = Jaeger::Thrift::Agent::Client.new(protocol)

--- a/lib/jaeger/udp_sender/transport.rb
+++ b/lib/jaeger/udp_sender/transport.rb
@@ -5,10 +5,11 @@ module Jaeger
     class Transport
       FLAGS = 0
 
-      def initialize(host, port)
+      def initialize(host, port, logger:)
         @socket = UDPSocket.new
         @host = host
         @port = port
+        @logger = logger
         @buffer = ::Thrift::MemoryBufferTransport.new
       end
 
@@ -31,9 +32,9 @@ module Jaeger
         @socket.send(bytes, FLAGS, @host, @port)
         @socket.flush
       rescue Errno::ECONNREFUSED
-        warn 'Unable to connect to Jaeger Agent'
+        @logger.warn 'Unable to connect to Jaeger Agent'
       rescue StandardError => e
-        warn "Unable to send spans: #{e.message}"
+        @logger.warn "Unable to send spans: #{e.message}"
       end
     end
   end

--- a/spec/jaeger/encoders/thrift_encoder_spec.rb
+++ b/spec/jaeger/encoders/thrift_encoder_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Jaeger::Encoders::ThriftEncoder do
     let(:example_span) { Jaeger::Span.new(context, 'example_op', nil) }
     let(:example_spans) { Array.new(150, example_span) }
 
-    let(:tags) { Array.new(20) { |index| ["key#{index}", "value#{index}"] }.to_h }
+    let(:tags) { Array.new(50) { |index| ["key#{index}", "value#{index}"] }.to_h }
     let(:max_length) { 5_000 }
 
     it 'size of every batch not exceed limit with compact protocol' do
@@ -167,6 +167,15 @@ RSpec.describe Jaeger::Encoders::ThriftEncoder do
         protocol = ::Thrift::CompactProtocol.new(transport)
         encoded_batch.write(protocol)
         expect(transport.available).to be < max_length
+      end
+    end
+
+    context 'when limit to low' do
+      let(:max_length) { 500 }
+
+      it 'raise error' do
+        expect { encoder.encode_limited_size(example_spans, ::Thrift::CompactProtocol, max_length) }
+          .to raise_error(StandardError, /Batch header have size \d+, but limit #{max_length}/)
       end
     end
   end


### PR DESCRIPTION
Hi!

We are faced with a loss of traces. We send traces to jaeger-agent via UDP. After investigation, we found the following messages in the logs:
```
Unable to send spans: Message too long - sendto(2) for "jaeger-agent" port 6831
``` 

After applying the proposed changes, we were able to find a problem: some of our spans were larger than 200kb after serialization. I think it might be useful for other users of the library as well.

The proposed changes are as follows:
- Batch sending errors are now output via the logger, instead of output to stdout. This can be useful for those who write logs in a specific format.
- The size of the butch header is subtracted from the message limit. This avoids problems when the header is too large, such as if it contains a lot of tags.
- If the header is greater than the butch limit, an exception will be thrown and the corresponding message will be logged.
- If the span is greater than the butch limit, it will be skipped and a warning will be logged. This will allow you not to lose the rest of the spans and understand which span is the problem.
- Fixed an issue where the size of the transition span was excluded from calculating the size of the next batch.